### PR TITLE
Fix: heartbeat task stack overflow

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -8,5 +8,12 @@ void app_main(void)
 {
     nvs_init();
     wifi_init();
-    xTaskCreate(heartbeat_task, "heartbeat_task", 4096, NULL, 5, NULL);
+    xTaskCreate(
+        heartbeat_task, 
+        "heartbeat_task", 
+        HEARTBEAT_TASK_STACK_SIZE, 
+        NULL, 
+        HEARTBEAT_TASK_PRIORITY, 
+        NULL
+    );
 }

--- a/main/wifi_config_example.h
+++ b/main/wifi_config_example.h
@@ -4,7 +4,6 @@
 // WiFi credentials and server URL for Testing
 #define WIFI_SSID "your_wifi_ssid"
 #define WIFI_PASSWORD "your_wifi_password"
-#define HEARTBEAT_INTERVAL_MS 60000
 #define SERVER_URL "http://your_server_url/heartbeat"
 #define SERIAL_NUMBER "ONGI-000"
 #define CONFIG_DEVICE_TOKEN "your_device_token"

--- a/main/wifi_heartbeat.c
+++ b/main/wifi_heartbeat.c
@@ -122,6 +122,10 @@ static void send_heartbeat() {
 // Heartbeat task
 void heartbeat_task(void *pvParameters) {
     while (1) {
+        // Wait for WiFi connection
+        xEventGroupWaitBits(wifi_event_group, WIFI_CONNECTED_BIT, false, true, portMAX_DELAY);
+        ESP_LOGI(TAG, "WiFi connected, sending heartbeat...");
+
         send_heartbeat();
         vTaskDelay(pdMS_TO_TICKS(HEARTBEAT_INTERVAL_MS));
     }

--- a/main/wifi_heartbeat.c
+++ b/main/wifi_heartbeat.c
@@ -9,7 +9,9 @@
 #include "freertos/event_groups.h"
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
+
 #include "wifi_config.h"
+#include "wifi_heartbeat.h"
 
 static const char *TAG = "ongi-wifi-heartbeat";
 static EventGroupHandle_t wifi_event_group;

--- a/main/wifi_heartbeat.h
+++ b/main/wifi_heartbeat.h
@@ -1,6 +1,10 @@
 #ifndef WIFI_HEARTBEAT_H
 #define WIFI_HEARTBEAT_H
 
+#define HEARTBEAT_TASK_STACK_SIZE 8192
+#define HEARTBEAT_TASK_PRIORITY 5
+#define HEARTBEAT_INTERVAL_MS 60000
+
 void wifi_init();
 void heartbeat_task(void *pvParameters);
 


### PR DESCRIPTION
## 📌 Related Issue

Closes #6 

## 🚀 Description
Resolved two issues in `heartbeat_task`:
1. stack overflow on second transmission $\to$ increase stack size
2. premature heartbeat before Wi-Fi is ready $\to$ add `WIFI_CONNECTED_BIT` wait at task start


## 📢 Review Point

<!-- 리뷰어가 중점적으로 봐야 할 내용을 작성해 주세요. -->

## 📚 Etc (선택)

<img width="1395" height="536" alt="image" src="https://github.com/user-attachments/assets/cde6fbb0-0d9a-4e0c-84a4-83914ffe528c" />