### PR TITLE
Feat: Define SlotEntry struct and implement schedule_task with hardcoded slots

### DIFF
--- a/components/dispense/CMakeLists.txt
+++ b/components/dispense/CMakeLists.txt
@@ -1,0 +1,12 @@
+idf_component_register(
+    SRCS "dispense.c" 
+    INCLUDE_DIRS "include"
+    REQUIRES schedule)
+if(CI_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
+    target_compile_options(${COMPONENT_LIB} PRIVATE 
+        -Wno-unused-function
+        -Wno-unused-variable
+        -Wno-unused-parameter
+    )
+endif()

--- a/components/dispense/dispense.c
+++ b/components/dispense/dispense.c
@@ -1,1 +1,49 @@
 #include "dispense.h"
+#include "esp_log.h"
+
+static const char *TAG = "dispense";
+static QueueHandle_t s_dispense_queue = NULL;
+
+esp_err_t dispense_init(void) {
+    s_dispense_queue= xQueueCreate(DISPENSE_QUEUE_LENGTH, sizeof(DispenseEvent));
+
+    if (s_dispense_queue == NULL) {
+        ESP_LOGE(TAG, "Failed to create dispense event queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "Dispense module initialized successfully");
+    return ESP_OK;
+}
+
+esp_err_t dispense_enqueue(uint8_t slot_id) {
+    if (s_dispense_queue == NULL) {
+        ESP_LOGE(TAG, "Dispense queue not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Create a dispense event with the specified slot ID
+    DispenseEvent event = { .slot_id = slot_id };
+
+    // Enqueue the dispense event without blocking; log an error if the queue is full
+    if (xQueueSend(s_dispense_queue, &event, 0) != pdTRUE) {
+        ESP_LOGE(TAG, "Failed to enqueue dispense event");
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+void dispense_task(void *arg) {
+    DispenseEvent event;
+
+    ESP_LOGI(TAG, "Dispense task started");
+
+    while (1) {
+        if (xQueueReceive(s_dispense_queue, &event, portMAX_DELAY) == pdTRUE) {
+            ESP_LOGI(TAG, "Processing dispense event for slot ID: %d", event.slot_id);
+        
+            // TODO: servo motor control
+        }
+    }
+}

--- a/components/dispense/dispense.c
+++ b/components/dispense/dispense.c
@@ -42,7 +42,7 @@ void dispense_task(void *arg) {
     while (1) {
         if (xQueueReceive(s_dispense_queue, &event, portMAX_DELAY) == pdTRUE) {
             ESP_LOGI(TAG, "Processing dispense event for slot ID: %d", event.slot_id);
-        
+
             // TODO: servo motor control
         }
     }

--- a/components/dispense/dispense.c
+++ b/components/dispense/dispense.c
@@ -1,0 +1,1 @@
+#include "dispense.h"

--- a/components/dispense/include/dispense.h
+++ b/components/dispense/include/dispense.h
@@ -1,4 +1,24 @@
 #ifndef DISPENSE_H
 #define DISPENSE_H
 
+#include <stdint.h>
+#include "esp_err.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+
+#define DISPENSE_QUEUE_LENGTH 10
+#define DISPENSE_TASK_STACK_SIZE 4096
+#define DISPENSE_TASK_PRIORITY 5
+
+typedef struct {
+    uint8_t slot_id;
+} DispenseEvent;
+
+extern QueueHandle_t dispense_event_queue;
+
+esp_err_t dispense_init(void);
+esp_err_t dispense_enqueue(uint8_t slot_id);
+void dispense_task(void *arg);
+
 #endif // DISPENSE_H

--- a/components/dispense/include/dispense.h
+++ b/components/dispense/include/dispense.h
@@ -1,0 +1,4 @@
+#ifndef DISPENSE_H
+#define DISPENSE_H
+
+#endif // DISPENSE_H

--- a/components/rtc/include/rtc_driver.h
+++ b/components/rtc/include/rtc_driver.h
@@ -24,7 +24,4 @@ bool rtc_driver_is_synced(void);
 // Task to start periodic RTC synchronization with NTP server
 esp_err_t rtc_start_sync_task(void);
 
-// Helper function to log the current RTC time for debugging purposes
-esp_err_t rtc_log_current_time(void);
-
 #endif // _RTC_DRIVER_H_

--- a/components/rtc/include/rtc_driver.h
+++ b/components/rtc/include/rtc_driver.h
@@ -24,4 +24,7 @@ bool rtc_driver_is_synced(void);
 // Task to start periodic RTC synchronization with NTP server
 esp_err_t rtc_start_sync_task(void);
 
+// Helper function to log the current RTC time for debugging purposes
+esp_err_t rtc_log_current_time(void);
+
 #endif // _RTC_DRIVER_H_

--- a/components/rtc/rtc_driver.c
+++ b/components/rtc/rtc_driver.c
@@ -11,6 +11,7 @@ static const RtcDriver INTERNAL_RTC_DRIVER = {
 };
 
 static TaskHandle_t s_rtc_sync_task_handle = NULL;
+static esp_err_t rtc_log_current_time(void);
 
 // Abstracted RTC driver interface implementation 
 esp_err_t rtc_driver_init(void) {
@@ -74,7 +75,7 @@ esp_err_t rtc_start_sync_task(void) {
     return ESP_OK;
 }
 
-esp_err_t rtc_log_current_time(void) {
+static esp_err_t rtc_log_current_time(void) {
     time_t now;
 
     esp_err_t ret = rtc_driver_get_time(&now);

--- a/components/rtc/rtc_driver.c
+++ b/components/rtc/rtc_driver.c
@@ -11,7 +11,6 @@ static const RtcDriver INTERNAL_RTC_DRIVER = {
 };
 
 static TaskHandle_t s_rtc_sync_task_handle = NULL;
-static esp_err_t rtc_log_current_time(void);
 
 // Abstracted RTC driver interface implementation 
 esp_err_t rtc_driver_init(void) {
@@ -31,13 +30,22 @@ bool rtc_driver_is_synced(void) {
 }
 
 static void rtc_sync_task(void *arg) {
-    esp_err_t ret = rtc_driver_sync();
+    while (1) {
+        if (rtc_driver_is_synced()) {
+            ESP_LOGI(TAG, "RTC is already synchronized");
+            break;
+        }
 
-    if (ret == ESP_OK) {
-        ESP_LOGI(TAG, "RTC synchronized successfully");
-        rtc_log_current_time();
-    } else {
-        ESP_LOGW(TAG, "RTC synchronization failed: %s", esp_err_to_name(ret));
+        esp_err_t ret = rtc_driver_sync();
+
+        if (ret == ESP_OK && rtc_driver_is_synced()) {
+            ESP_LOGI(TAG, "RTC synchronized successfully");
+            rtc_log_current_time();
+            break;
+        } 
+    
+        ESP_LOGW(TAG, "RTC sync not completed, retrying in 10 seconds...");
+        vTaskDelay(pdMS_TO_TICKS(10000)); 
     }
 
     s_rtc_sync_task_handle = NULL;
@@ -66,7 +74,7 @@ esp_err_t rtc_start_sync_task(void) {
     return ESP_OK;
 }
 
-static esp_err_t rtc_log_current_time(void) {
+esp_err_t rtc_log_current_time(void) {
     time_t now;
 
     esp_err_t ret = rtc_driver_get_time(&now);

--- a/components/rtc/rtc_internal.c
+++ b/components/rtc/rtc_internal.c
@@ -7,7 +7,7 @@
 #include "esp_netif_sntp.h"
 
 static const char *TAG = "rtc_internal";
-static bool s_synced = false;
+static volatile bool s_synced = false;
 static bool s_sntp_initialized = false;
 
 // Callback function called when time is synchronized

--- a/components/schedule/CMakeLists.txt
+++ b/components/schedule/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "schedule.c" 
     INCLUDE_DIRS "include"
-    REQUIRES rtc)
+    REQUIRES rtc dispense)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/schedule/CMakeLists.txt
+++ b/components/schedule/CMakeLists.txt
@@ -1,0 +1,12 @@
+idf_component_register(
+    SRCS ""
+    INCLUDE_DIRS "include"
+    REQUIRES )
+if(CI_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
+    target_compile_options(${COMPONENT_LIB} PRIVATE 
+        -Wno-unused-function
+        -Wno-unused-variable
+        -Wno-unused-parameter
+    )
+endif()

--- a/components/schedule/CMakeLists.txt
+++ b/components/schedule/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "schedule.c" 
     INCLUDE_DIRS "include"
-    REQUIRES )
+    REQUIRES rtc)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/schedule/CMakeLists.txt
+++ b/components/schedule/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS ""
+    SRCS "schedule.c" 
     INCLUDE_DIRS "include"
     REQUIRES )
 if(CI_BUILD)

--- a/components/schedule/include/schedule.h
+++ b/components/schedule/include/schedule.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 
 #define SCHEDULE_SLOT_COUNT 8
+#define SCHEDULE_TASK_STACK_SIZE 4096
+#define SCHEDULE_TASK_PRIORITY 5
 
 typedef struct {
     uint8_t slot_id;
@@ -17,7 +19,6 @@ typedef struct {
     uint8_t slot_id;
 } DispenseEvent;
 
-// SlotEntry Test
-void init_test_slots(SlotEntry *slots, size_t count);
+void schedule_task(void *arg);
 
 #endif  // SCHEDULE_H

--- a/components/schedule/include/schedule.h
+++ b/components/schedule/include/schedule.h
@@ -1,0 +1,19 @@
+#ifndef SCHEDULE_H
+#define SCHEDULE_H
+
+#include <stdint.h>
+
+#define SCHEDULE_SLOT_COUNT 8
+
+typedef struct {
+    uint8_t slot_id;
+    uint8_t hour;
+    uint8_t minute;
+    bool triggered;
+} SlotEntry;
+
+typedef struct {
+    uint8_t slot_id;
+} DispenseEvent;
+
+#endif  // SCHEDULE_H

--- a/components/schedule/include/schedule.h
+++ b/components/schedule/include/schedule.h
@@ -15,10 +15,6 @@ typedef struct {
     bool triggered;
 } SlotEntry;
 
-typedef struct {
-    uint8_t slot_id;
-} DispenseEvent;
-
 void schedule_task(void *arg);
 
 #endif  // SCHEDULE_H

--- a/components/schedule/include/schedule.h
+++ b/components/schedule/include/schedule.h
@@ -2,6 +2,7 @@
 #define SCHEDULE_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #define SCHEDULE_SLOT_COUNT 8
 
@@ -15,5 +16,8 @@ typedef struct {
 typedef struct {
     uint8_t slot_id;
 } DispenseEvent;
+
+// SlotEntry Test
+void init_test_slots(SlotEntry *slots, size_t count);
 
 #endif  // SCHEDULE_H

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -1,0 +1,27 @@
+#include "schedule.h"
+#include "esp_log.h"
+#include <time.h>
+
+static const char *TAG = "schedule";
+
+void init_test_slots(SlotEntry *slots, size_t count) {
+    time_t now_sec;
+    struct tm now;
+
+    time(&now_sec);
+    localtime_r(&now_sec, &now);
+
+    for (int i=0; i<count; i++) {
+        struct tm slot_time = now;
+        slot_time.tm_min += i+1; // 1-minute intervals from current time
+
+        mktime(&slot_time); // Normalize time structure
+
+        slots[i].slot_id = i+1;
+        slots[i].hour = slot_time.tm_hour;
+        slots[i].minute = slot_time.tm_min;
+        slots[i].triggered = false;
+
+        ESP_LOGI(TAG, "test slot %d => %02d:%02d", slots[i].slot_id, slots[i].hour, slots[i].minute);
+    }
+}

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -87,12 +87,15 @@ void schedule_task(void *arg) {
 
             if (now_tm.tm_hour == slot->hour && now_tm.tm_min == slot->minute) {
                 ESP_LOGI(TAG, "Slot matched! slot = %d, time = %02d:%02d", slot->slot_id, slot->hour, slot->minute);
-                // Trigger the dispense event for the matched slot
+                
+                // Enqueue dispense event for the matched slot
                 esp_err_t err = dispense_enqueue(slot->slot_id);
-                if (err != ESP_OK) {
+                if (err == ESP_OK) {
+                    ESP_LOGI(TAG, "Dispense event enqueued for slot %d", slot->slot_id);
+                    slot->triggered = true; // Mark slot as triggered to prevent retriggering within the same minute
+                } else {
                     ESP_LOGE(TAG, "Failed to enqueue dispense event for slot %d: %s", slot->slot_id, esp_err_to_name(err));
                 }
-                slot->triggered = true;
             }
         }    
         vTaskDelay(pdMS_TO_TICKS(1000)); 

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -31,6 +31,12 @@ static void init_test_slots(SlotEntry *slots, size_t count) {
     }
 }
 
+static void reset_trigger_flags(SlotEntry *slots, size_t count) {
+    for (int i=0; i<count; i++) {
+        slots[i].triggered = false;
+    }
+}
+
 esp_err_t schedule_init(SlotEntry *slots, size_t count) {
     if (slots == NULL || count == 0) {
         return ESP_ERR_INVALID_ARG;
@@ -54,6 +60,8 @@ void schedule_task(void *arg) {
     // Initialize schedule slots (for testing, we create slots at 1-minute intervals from current time)
     SlotEntry slots[SCHEDULE_SLOT_COUNT];
     schedule_init(slots, SCHEDULE_SLOT_COUNT);
+    
+    int last_day = -1; // To track day changes and reset triggered flags
 
     // Main loop to check and trigger scheduled slots
     while (1) {
@@ -62,6 +70,13 @@ void schedule_task(void *arg) {
 
         struct tm now_tm;
         localtime_r(&now, &now_tm);
+
+        if (now_tm.tm_mday != last_day) {
+            ESP_LOGI(TAG, "Day changed, resetting triggered flags");
+
+            reset_trigger_flags(slots, SCHEDULE_SLOT_COUNT);
+            last_day = now_tm.tm_mday;
+        }
 
         for (int i=0; i<SCHEDULE_SLOT_COUNT; i++) {
             SlotEntry *slot = &slots[i];

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -1,5 +1,6 @@
 #include "schedule.h"
 #include "rtc_driver.h"
+#include "dispense.h"
 #include "esp_log.h"
 #include "esp_err.h"
 #include <time.h>
@@ -71,6 +72,11 @@ void schedule_task(void *arg) {
 
             if (now_tm.tm_hour == slot->hour && now_tm.tm_min == slot->minute) {
                 ESP_LOGI(TAG, "Slot matched! slot = %d, time = %02d:%02d", slot->slot_id, slot->hour, slot->minute);
+                // Trigger the dispense event for the matched slot
+                esp_err_t err = dispense_enqueue(slot->slot_id);
+                if (err != ESP_OK) {
+                    ESP_LOGE(TAG, "Failed to enqueue dispense event for slot %d: %s", slot->slot_id, esp_err_to_name(err));
+                }
                 slot->triggered = true;
             }
         }    

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -56,7 +56,24 @@ void schedule_task(void *arg) {
 
     // Main loop to check and trigger scheduled slots
     while (1) {
-       rtc_log_current_time(); // Log current time for debugging
-       vTaskDelay(pdMS_TO_TICKS(1000)); 
-    }
+        time_t now;
+        rtc_driver_get_time(&now);
+
+        struct tm now_tm;
+        localtime_r(&now, &now_tm);
+
+        for (int i=0; i<SCHEDULE_SLOT_COUNT; i++) {
+            SlotEntry *slot = &slots[i];
+
+            if (slot->triggered) {
+                continue; // Skip already triggered slots
+            }
+
+            if (now_tm.tm_hour == slot->hour && now_tm.tm_min == slot->minute) {
+                ESP_LOGI(TAG, "Slot matched! slot = %d, time = %02d:%02d", slot->slot_id, slot->hour, slot->minute);
+                slot->triggered = true;
+            }
+        }    
+        vTaskDelay(pdMS_TO_TICKS(1000)); 
+    } 
 }

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -1,15 +1,19 @@
 #include "schedule.h"
+#include "rtc_driver.h"
 #include "esp_log.h"
+#include "esp_err.h"
 #include <time.h>
 
 static const char *TAG = "schedule";
 
-void init_test_slots(SlotEntry *slots, size_t count) {
+static void init_test_slots(SlotEntry *slots, size_t count) {
     time_t now_sec;
     struct tm now;
 
     time(&now_sec);
     localtime_r(&now_sec, &now);
+    
+    ESP_LOGI(TAG, "init_test_slots called");
 
     for (int i=0; i<count; i++) {
         struct tm slot_time = now;
@@ -23,5 +27,36 @@ void init_test_slots(SlotEntry *slots, size_t count) {
         slots[i].triggered = false;
 
         ESP_LOGI(TAG, "test slot %d => %02d:%02d", slots[i].slot_id, slots[i].hour, slots[i].minute);
+    }
+}
+
+esp_err_t schedule_init(SlotEntry *slots, size_t count) {
+    if (slots == NULL || count == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    init_test_slots(slots, count);
+    return ESP_OK;
+}
+
+void schedule_task(void *arg) {
+    ESP_LOGI(TAG, "Schedule task started");
+
+    // Wait for RTC synchronization before starting the schedule task
+    while (!rtc_driver_is_synced()) {
+        ESP_LOGI(TAG, "Waiting for RTC synchronization...");
+        vTaskDelay(pdMS_TO_TICKS(3000));
+    }
+
+    ESP_LOGI(TAG, "RTC synchronized, starting schedule monitoring");
+
+    // Initialize schedule slots (for testing, we create slots at 1-minute intervals from current time)
+    SlotEntry slots[SCHEDULE_SLOT_COUNT];
+    schedule_init(slots, SCHEDULE_SLOT_COUNT);
+
+    // Main loop to check and trigger scheduled slots
+    while (1) {
+       rtc_log_current_time(); // Log current time for debugging
+       vTaskDelay(pdMS_TO_TICKS(1000)); 
     }
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES storage wifi rtc)
+    REQUIRES storage wifi rtc schedule)
 
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES storage wifi rtc schedule)
+    REQUIRES storage wifi rtc schedule dispense)
 
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)

--- a/main/main.c
+++ b/main/main.c
@@ -3,6 +3,7 @@
 #include "storage_nvs.h"
 #include "rtc_driver.h"
 #include "schedule.h"
+#include "dispense.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -43,6 +44,27 @@ void app_main(void)
     if (heartbeat_task_created != pdPASS) {
         ESP_LOGE(TAG, "Failed to create heartbeat task");
         return;
+    }
+
+    // Initialize dispense module and check for errors
+    err = dispense_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize dispense");
+        return;
+    }
+
+    // Create the dispense task
+    BaseType_t dispense_task_created = xTaskCreate(
+        dispense_task,
+        "dispense_task",
+        DISPENSE_TASK_STACK_SIZE,
+        NULL,
+        DISPENSE_TASK_PRIORITY,
+        NULL
+    );
+    if (dispense_task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create dispense task");
+        return; 
     }
 
     // Create the schedule task

--- a/main/main.c
+++ b/main/main.c
@@ -2,6 +2,7 @@
 #include "wifi_heartbeat.h"
 #include "storage_nvs.h"
 #include "rtc_driver.h"
+#include "schedule.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -42,5 +43,20 @@ void app_main(void)
     if (heartbeat_task_created != pdPASS) {
         ESP_LOGE(TAG, "Failed to create heartbeat task");
         return;
+    }
+
+    // Create the schedule task
+    BaseType_t schedule_task_created = xTaskCreate(
+        schedule_task,
+        "schedule_task",
+        SCHEDULE_TASK_STACK_SIZE,
+        NULL,
+        SCHEDULE_TASK_PRIORITY,
+        NULL
+    );
+
+    if (schedule_task_created != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create schedule task");
+        return; 
     }
 }


### PR DESCRIPTION
## 📌 Related Issue

Closes #16 

## 🚀 Description
Implements `schedule_task` that periodically checks current RTC time against hardcoded test slots and dispatches dispense events via queue.
- Define SlotEntry and dispense event structures
- Hardcode 8 test slots at 1-minute intervals for easy validation
- Implement `schedule_task`
    - Query current time via `RtcDriver` every 1s
    - Match against slots and push to `dispense_queue` on hit
    - Prevent duplicate triggers with `triggered` flag
    - Reset `triggered` flags at midnight (00:00) 

## 📢 Review Point
- Timing of `triggered` flag reset (midnight reset logic)
- Behavior when `dispense_queue` push fails
- Behavior of  `schedule_task` when RTC is not yet synced

## 📚 Etc (선택)
- Hardcoded slots are for testing purposes and will be replaced by server-fetched schedules
<img width="600" alt="Screenshot 2026-05-17 000127" src="https://github.com/user-attachments/assets/2e22a613-75df-4f6b-bbe4-3f162eab6f9e" />
<img width="600" alt="Screenshot 2026-05-17 000202" src="https://github.com/user-attachments/assets/0813cfd3-eb1e-41e7-8a97-141246230467" />
<img width="600" alt="Screenshot 2026-05-17 000215" src="https://github.com/user-attachments/assets/d029dcc3-cd05-490e-832e-299e7df58d52" />

- All 8 slots triggered correctly at 1-minute intervals from 23:53 to 00:00
- with day-change detection and `triggered` flag reset working as expected at midnight.