### PR TITLE
Feat: Prepare schedule API integration

### DIFF
--- a/components/schedule/CMakeLists.txt
+++ b/components/schedule/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "schedule.c" 
+    SRCS "schedule.c" "schedule_store.c"
     INCLUDE_DIRS "include"
     REQUIRES rtc dispense)
 if(CI_BUILD)

--- a/components/schedule/include/schedule_store.h
+++ b/components/schedule/include/schedule_store.h
@@ -1,0 +1,20 @@
+#ifndef SCHEDULE_STORE_H
+#define SCHEDULE_STORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "schedule.h"
+
+typedef struct {
+    SlotEntry slots[SCHEDULE_SLOT_COUNT];
+    size_t count; // Number of valid slots in the snapshot
+    uint32_t version;
+} ScheduleSnapshot;
+
+esp_err_t schedule_store_init(void);
+esp_err_t schedule_store_apply(const SlotEntry *slots, size_t count);
+esp_err_t schedule_store_get_snapshot(ScheduleSnapshot *snapshot);
+esp_err_t schedule_store_clear(void);
+
+#endif // SCHEDULE_STORE_H

--- a/components/schedule/include/schedule_store.h
+++ b/components/schedule/include/schedule_store.h
@@ -14,6 +14,7 @@ typedef struct {
 
 esp_err_t schedule_store_init(void);
 esp_err_t schedule_store_apply(const SlotEntry *slots, size_t count);
+esp_err_t schedule_store_apply_fixture(void);
 esp_err_t schedule_store_get_snapshot(ScheduleSnapshot *snapshot);
 esp_err_t schedule_store_clear(void);
 

--- a/components/schedule/include/schedule_store.h
+++ b/components/schedule/include/schedule_store.h
@@ -16,6 +16,8 @@ esp_err_t schedule_store_init(void);
 esp_err_t schedule_store_apply(const SlotEntry *slots, size_t count);
 esp_err_t schedule_store_apply_fixture(void);
 esp_err_t schedule_store_get_snapshot(ScheduleSnapshot *snapshot);
+esp_err_t schedule_store_request_refresh(void);
+esp_err_t schedule_store_consume_refresh_request(bool *was_pending, uint32_t *request_count);
 esp_err_t schedule_store_clear(void);
 
 #endif // SCHEDULE_STORE_H

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -1,49 +1,16 @@
 #include "schedule.h"
+#include "schedule_store.h"
 #include "rtc_driver.h"
 #include "dispense.h"
 #include "esp_log.h"
 #include "esp_err.h"
+#include <string.h>
 #include <time.h>
 
 static const char *TAG = "schedule";
 
-static void init_test_slots(SlotEntry *slots, size_t count) {
-    time_t now_sec;
-    struct tm now;
-
-    time(&now_sec);
-    localtime_r(&now_sec, &now);
-    
-    ESP_LOGI(TAG, "init_test_slots called");
-
-    for (int i=0; i<count; i++) {
-        struct tm slot_time = now;
-        slot_time.tm_min += i+1; // 1-minute intervals from current time
-
-        mktime(&slot_time); // Normalize time structure
-
-        slots[i].slot_id = i+1;
-        slots[i].hour = slot_time.tm_hour;
-        slots[i].minute = slot_time.tm_min;
-        slots[i].triggered = false;
-
-        ESP_LOGI(TAG, "test slot %d => %02d:%02d", slots[i].slot_id, slots[i].hour, slots[i].minute);
-    }
-}
-
-static void reset_trigger_flags(SlotEntry *slots, size_t count) {
-    for (int i=0; i<count; i++) {
-        slots[i].triggered = false;
-    }
-}
-
-esp_err_t schedule_init(SlotEntry *slots, size_t count) {
-    if (slots == NULL || count == 0) {
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    init_test_slots(slots, count);
-    return ESP_OK;
+static void reset_trigger_flags(bool *triggered_slots, size_t count) {
+    memset(triggered_slots, 0, count * sizeof(bool));
 }
 
 void schedule_task(void *arg) {
@@ -57,44 +24,74 @@ void schedule_task(void *arg) {
 
     ESP_LOGI(TAG, "RTC synchronized, starting schedule monitoring");
 
-    // Initialize schedule slots (for testing, we create slots at 1-minute intervals from current time)
-    SlotEntry slots[SCHEDULE_SLOT_COUNT];
-    schedule_init(slots, SCHEDULE_SLOT_COUNT);
-    
+    bool triggered_slots[SCHEDULE_SLOT_COUNT + 1] = { false };
+    uint32_t last_version = UINT32_MAX;
     int last_day = -1; // To track day changes and reset triggered flags
 
     // Main loop to check and trigger scheduled slots
     while (1) {
         time_t now;
-        rtc_driver_get_time(&now);
+        // Get current time from RTC
+        esp_err_t err = rtc_driver_get_time(&now);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to get RTC time: %s", esp_err_to_name(err));
+            vTaskDelay(pdMS_TO_TICKS(1000));
+            continue;
+        }
 
         struct tm now_tm;
         localtime_r(&now, &now_tm);
 
+        // Load the latest schedule snapshot
+        ScheduleSnapshot snapshot;
+        err = schedule_store_get_snapshot(&snapshot);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to load schedule snapshot: %s", esp_err_to_name(err));
+            vTaskDelay(pdMS_TO_TICKS(1000));
+            continue;
+        }
+
+        // Check if the schedule version has changed, indicating an update to the schedule
+        if (snapshot.version != last_version) {
+            reset_trigger_flags(triggered_slots, SCHEDULE_SLOT_COUNT + 1);
+            last_version = snapshot.version;
+            ESP_LOGI(TAG, "Loaded schedule snapshot: count=%u version=%u",
+                     (unsigned int)snapshot.count,
+                     (unsigned int)snapshot.version);
+        }
+
         if (now_tm.tm_mday != last_day) {
             ESP_LOGI(TAG, "Day changed, resetting triggered flags");
 
-            reset_trigger_flags(slots, SCHEDULE_SLOT_COUNT);
+            reset_trigger_flags(triggered_slots, SCHEDULE_SLOT_COUNT + 1);
             last_day = now_tm.tm_mday;
         }
 
-        for (int i=0; i<SCHEDULE_SLOT_COUNT; i++) {
-            SlotEntry *slot = &slots[i];
+        // Iterate through the schedule slots and trigger any that match the current time
+        for (size_t i = 0; i < snapshot.count; i++) {
+            const SlotEntry *slot = &snapshot.slots[i];
+            uint8_t slot_id = slot->slot_id;
 
-            if (slot->triggered) {
+            if (slot_id == 0 || slot_id > SCHEDULE_SLOT_COUNT) {
+                ESP_LOGW(TAG, "Skipping invalid schedule slot id: %u", (unsigned int)slot_id);
+                continue;
+            }
+
+            if (triggered_slots[slot_id]) {
                 continue; // Skip already triggered slots
             }
 
+            // Check if the current time matches the scheduled time for this slot
             if (now_tm.tm_hour == slot->hour && now_tm.tm_min == slot->minute) {
-                ESP_LOGI(TAG, "Slot matched! slot = %d, time = %02d:%02d", slot->slot_id, slot->hour, slot->minute);
+                ESP_LOGI(TAG, "Slot matched! slot = %d, time = %02d:%02d", slot_id, slot->hour, slot->minute);
                 
                 // Enqueue dispense event for the matched slot
-                esp_err_t err = dispense_enqueue(slot->slot_id);
+                err = dispense_enqueue(slot_id);
                 if (err == ESP_OK) {
-                    ESP_LOGI(TAG, "Dispense event enqueued for slot %d", slot->slot_id);
-                    slot->triggered = true; // Mark slot as triggered to prevent retriggering within the same minute
+                    ESP_LOGI(TAG, "Dispense event enqueued for slot %d", slot_id);
+                    triggered_slots[slot_id] = true; // Mark slot as triggered to prevent retriggering within the same day
                 } else {
-                    ESP_LOGE(TAG, "Failed to enqueue dispense event for slot %d: %s", slot->slot_id, esp_err_to_name(err));
+                    ESP_LOGE(TAG, "Failed to enqueue dispense event for slot %d: %s", slot_id, esp_err_to_name(err));
                 }
             }
         }    

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -9,8 +9,48 @@
 
 static const char *TAG = "schedule";
 
-static void reset_trigger_flags(bool *triggered_slots, size_t count) {
-    memset(triggered_slots, 0, count * sizeof(bool));
+typedef struct {
+    uint8_t slot_id;
+    uint8_t hour;
+    uint8_t minute;
+    int day;
+    bool triggered;
+} TriggerRecord;
+
+static void reset_trigger_records(TriggerRecord *records, size_t count) {
+    memset(records, 0, count * sizeof(TriggerRecord));
+}
+
+static bool was_triggered_today(const TriggerRecord *records, size_t count, const SlotEntry *slot, int day) {
+    for (size_t i = 0; i < count; i++) {
+        if (records[i].triggered &&
+            records[i].day == day &&
+            records[i].slot_id == slot->slot_id &&
+            records[i].hour == slot->hour &&
+            records[i].minute == slot->minute) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void mark_triggered_today(TriggerRecord *records, size_t count, const SlotEntry *slot, int day) {
+    for (size_t i = 0; i < count; i++) {
+        if (!records[i].triggered) {
+            records[i].slot_id = slot->slot_id;
+            records[i].hour = slot->hour;
+            records[i].minute = slot->minute;
+            records[i].day = day;
+            records[i].triggered = true;
+            return;
+        }
+    }
+
+    ESP_LOGW(TAG, "No room to record triggered slot: slot=%u time=%02u:%02u",
+             (unsigned int)slot->slot_id,
+             (unsigned int)slot->hour,
+             (unsigned int)slot->minute);
 }
 
 void schedule_task(void *arg) {
@@ -24,7 +64,7 @@ void schedule_task(void *arg) {
 
     ESP_LOGI(TAG, "RTC synchronized, starting schedule monitoring");
 
-    bool triggered_slots[SCHEDULE_SLOT_COUNT + 1] = { false };
+    TriggerRecord trigger_records[SCHEDULE_SLOT_COUNT] = { 0 };
     uint32_t last_version = UINT32_MAX;
     int last_day = -1; // To track day changes and reset triggered flags
 
@@ -53,7 +93,6 @@ void schedule_task(void *arg) {
 
         // Check if the schedule version has changed, indicating an update to the schedule
         if (snapshot.version != last_version) {
-            reset_trigger_flags(triggered_slots, SCHEDULE_SLOT_COUNT + 1);
             last_version = snapshot.version;
             ESP_LOGI(TAG, "Loaded schedule snapshot: count=%u version=%u",
                      (unsigned int)snapshot.count,
@@ -63,7 +102,7 @@ void schedule_task(void *arg) {
         if (now_tm.tm_mday != last_day) {
             ESP_LOGI(TAG, "Day changed, resetting triggered flags");
 
-            reset_trigger_flags(triggered_slots, SCHEDULE_SLOT_COUNT + 1);
+            reset_trigger_records(trigger_records, SCHEDULE_SLOT_COUNT);
             last_day = now_tm.tm_mday;
         }
 
@@ -77,7 +116,7 @@ void schedule_task(void *arg) {
                 continue;
             }
 
-            if (triggered_slots[slot_id]) {
+            if (was_triggered_today(trigger_records, SCHEDULE_SLOT_COUNT, slot, now_tm.tm_mday)) {
                 continue; // Skip already triggered slots
             }
 
@@ -89,7 +128,7 @@ void schedule_task(void *arg) {
                 err = dispense_enqueue(slot_id);
                 if (err == ESP_OK) {
                     ESP_LOGI(TAG, "Dispense event enqueued for slot %d", slot_id);
-                    triggered_slots[slot_id] = true; // Mark slot as triggered to prevent retriggering within the same day
+                    mark_triggered_today(trigger_records, SCHEDULE_SLOT_COUNT, slot, now_tm.tm_mday);
                 } else {
                     ESP_LOGE(TAG, "Failed to enqueue dispense event for slot %d: %s", slot_id, esp_err_to_name(err));
                 }

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -13,6 +13,28 @@ static SlotEntry s_slots[SCHEDULE_SLOT_COUNT];
 static size_t s_slot_count = 0;
 static uint32_t s_version = 0;
 
+static const SlotEntry s_fixture_slots[] = {
+    { .slot_id = 1, .hour = 7, .minute = 0, .triggered = false },
+    { .slot_id = 2, .hour = 8, .minute = 30, .triggered = false },
+    { .slot_id = 3, .hour = 10, .minute = 0, .triggered = false },
+    { .slot_id = 4, .hour = 12, .minute = 30, .triggered = false },
+    { .slot_id = 5, .hour = 15, .minute = 0, .triggered = false },
+    { .slot_id = 6, .hour = 18, .minute = 30, .triggered = false },
+    { .slot_id = 7, .hour = 21, .minute = 0, .triggered = false },
+    { .slot_id = 8, .hour = 22, .minute = 30, .triggered = false },
+};
+
+static void log_applied_slots(const SlotEntry *slots, size_t count, uint32_t version)
+{
+    for (size_t i = 0; i < count; i++) {
+        ESP_LOGI(TAG, "active slot: version=%u slot_id=%u time=%02u:%02u",
+                 (unsigned int)version,
+                 (unsigned int)slots[i].slot_id,
+                 (unsigned int)slots[i].hour,
+                 (unsigned int)slots[i].minute);
+    }
+}
+
 static esp_err_t validate_slots(const SlotEntry *slots, size_t count)
 {
     if (count > SCHEDULE_SLOT_COUNT) {
@@ -89,7 +111,15 @@ esp_err_t schedule_store_apply(const SlotEntry *slots, size_t count)
     ESP_LOGI(TAG, "Applied schedule snapshot: count=%u version=%u",
              (unsigned int)count,
              (unsigned int)s_version);
+    log_applied_slots(slots, count, s_version);
     return ESP_OK;
+}
+
+// Apply a predefined fixture schedule for testing purposes
+esp_err_t schedule_store_apply_fixture(void)
+{
+    ESP_LOGI(TAG, "Applying fixture schedule data");
+    return schedule_store_apply(s_fixture_slots, sizeof(s_fixture_slots) / sizeof(s_fixture_slots[0]));
 }
 
 // Get a snapshot of the current schedule store data

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -39,6 +39,8 @@ static void log_applied_slots(const SlotEntry *slots, size_t count, uint32_t ver
 
 static esp_err_t validate_slots(const SlotEntry *slots, size_t count)
 {
+    bool used_slots[SCHEDULE_SLOT_COUNT + 1] = { false };
+
     if (count > SCHEDULE_SLOT_COUNT) {
         return ESP_ERR_INVALID_SIZE;
     }
@@ -52,6 +54,14 @@ static esp_err_t validate_slots(const SlotEntry *slots, size_t count)
             slots[i].hour > 23 || slots[i].minute > 59) {
             return ESP_ERR_INVALID_ARG;
         }
+
+        if (used_slots[slots[i].slot_id]) {
+            ESP_LOGE(TAG, "Duplicate schedule slot id: slot_id=%u",
+                     (unsigned int)slots[i].slot_id);
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        used_slots[slots[i].slot_id] = true;
     }
 
     return ESP_OK;

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -12,14 +12,16 @@ static SemaphoreHandle_t s_schedule_mutex = NULL;
 static SlotEntry s_slots[SCHEDULE_SLOT_COUNT];
 static size_t s_slot_count = 0;
 static uint32_t s_version = 0;
+static bool s_refresh_pending = false;
+static uint32_t s_refresh_request_count = 0;
 
 static const SlotEntry s_fixture_slots[] = {
     { .slot_id = 1, .hour = 7, .minute = 0, .triggered = false },
     { .slot_id = 2, .hour = 8, .minute = 30, .triggered = false },
     { .slot_id = 3, .hour = 10, .minute = 0, .triggered = false },
-    { .slot_id = 4, .hour = 12, .minute = 30, .triggered = false },
-    { .slot_id = 5, .hour = 15, .minute = 0, .triggered = false },
-    { .slot_id = 6, .hour = 18, .minute = 30, .triggered = false },
+    { .slot_id = 4, .hour = 20, .minute = 5, .triggered = false },
+    { .slot_id = 5, .hour = 20, .minute = 10, .triggered = false },
+    { .slot_id = 6, .hour = 20, .minute = 30, .triggered = false },
     { .slot_id = 7, .hour = 21, .minute = 0, .triggered = false },
     { .slot_id = 8, .hour = 22, .minute = 30, .triggered = false },
 };
@@ -71,6 +73,8 @@ esp_err_t schedule_store_init(void)
     // Initialize the schedule store with empty data
     s_slot_count = 0;
     s_version = 0;
+    s_refresh_pending = false;
+    s_refresh_request_count = 0;
     memset(s_slots, 0, sizeof(s_slots));
 
     ESP_LOGI(TAG, "Schedule store initialized");
@@ -145,6 +149,56 @@ esp_err_t schedule_store_get_snapshot(ScheduleSnapshot *snapshot)
     snapshot->version = s_version;
 
     // Release the mutex after reading the data
+    xSemaphoreGive(s_schedule_mutex);
+
+    return ESP_OK;
+}
+
+// SCHEDULE_UPDATED from MQTT
+esp_err_t schedule_store_request_refresh(void)
+{
+    if (s_schedule_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Acquire the mutex to safely update the refresh request state
+    if (xSemaphoreTake(s_schedule_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Critical section: set the refresh pending flag and increment the request count
+    s_refresh_pending = true;
+    s_refresh_request_count++;
+    uint32_t request_count = s_refresh_request_count;
+
+    // Release the mutex after updating the refresh request state
+    xSemaphoreGive(s_schedule_mutex);
+
+    ESP_LOGI(TAG, "Schedule refresh requested: request_count=%u", (unsigned int)request_count);
+    return ESP_OK;
+}
+
+esp_err_t schedule_store_consume_refresh_request(bool *was_pending, uint32_t *request_count)
+{
+    if (was_pending == NULL || request_count == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (s_schedule_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Acquire the mutex to safely read and update the refresh request state
+    if (xSemaphoreTake(s_schedule_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Critical section: return the current refresh pending state and request count, then reset the pending flag
+    *was_pending = s_refresh_pending;
+    *request_count = s_refresh_request_count;
+    s_refresh_pending = false;
+
+    // Release the mutex after reading and updating the refresh request state
     xSemaphoreGive(s_schedule_mutex);
 
     return ESP_OK;

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -1,0 +1,127 @@
+#include "schedule_store.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static const char *TAG = "schedule_store";
+
+static SemaphoreHandle_t s_schedule_mutex = NULL;
+static SlotEntry s_slots[SCHEDULE_SLOT_COUNT];
+static size_t s_slot_count = 0;
+static uint32_t s_version = 0;
+
+static esp_err_t validate_slots(const SlotEntry *slots, size_t count)
+{
+    if (count > SCHEDULE_SLOT_COUNT) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    if (count > 0 && slots == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        if (slots[i].slot_id == 0 || slots[i].slot_id > SCHEDULE_SLOT_COUNT ||
+            slots[i].hour > 23 || slots[i].minute > 59) {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t schedule_store_init(void)
+{
+    if (s_schedule_mutex != NULL) {
+        return ESP_OK;
+    }
+
+    // Create a mutex for synchronizing access to the schedule store
+    s_schedule_mutex = xSemaphoreCreateMutex();
+    if (s_schedule_mutex == NULL) {
+        ESP_LOGE(TAG, "Failed to create schedule store mutex");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Initialize the schedule store with empty data
+    s_slot_count = 0;
+    s_version = 0;
+    memset(s_slots, 0, sizeof(s_slots));
+
+    ESP_LOGI(TAG, "Schedule store initialized");
+    return ESP_OK;
+}
+
+// Replace the entire schedule store data with the provided slots and count
+esp_err_t schedule_store_apply(const SlotEntry *slots, size_t count)
+{
+    esp_err_t err = validate_slots(slots, count);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid schedule data: err=%s count=%u",
+                 esp_err_to_name(err),
+                 (unsigned int)count);
+        return err;
+    }
+
+    if (s_schedule_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Acquire the mutex to safely update the schedule store data
+    if (xSemaphoreTake(s_schedule_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Critical section: update the schedule store data
+    memset(s_slots, 0, sizeof(s_slots));
+    if (count > 0) {
+        memcpy(s_slots, slots, count * sizeof(SlotEntry));
+    }
+    s_slot_count = count;
+    s_version++;
+
+    // Release the mutex after updating the data
+    xSemaphoreGive(s_schedule_mutex);
+
+    ESP_LOGI(TAG, "Applied schedule snapshot: count=%u version=%u",
+             (unsigned int)count,
+             (unsigned int)s_version);
+    return ESP_OK;
+}
+
+// Get a snapshot of the current schedule store data
+esp_err_t schedule_store_get_snapshot(ScheduleSnapshot *snapshot)
+{
+    if (snapshot == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (s_schedule_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Acquire the mutex to safely read the schedule store data
+    if (xSemaphoreTake(s_schedule_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Critical section: copy the current schedule store data into the snapshot
+    memset(snapshot, 0, sizeof(*snapshot));
+    memcpy(snapshot->slots, s_slots, s_slot_count * sizeof(SlotEntry));
+    snapshot->count = s_slot_count;
+    snapshot->version = s_version;
+
+    // Release the mutex after reading the data
+    xSemaphoreGive(s_schedule_mutex);
+
+    return ESP_OK;
+}
+
+// Clear all schedule slots from the store
+esp_err_t schedule_store_clear(void)
+{
+    return schedule_store_apply(NULL, 0);
+}

--- a/main/main.c
+++ b/main/main.c
@@ -63,13 +63,14 @@ void app_main(void)
         return;
     }
 
-    // TODO: Temporary fixture schedule for store integration testing.
-    // Remove this before using API-provided schedules or real hardware.
+#ifdef CI_BUILD
+    // Temporary fixture schedule for CI/store integration testing only.
     err = schedule_store_apply_fixture();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to apply fixture schedule");
         return;
     }
+#endif
 
     // Initialize event queue and check for errors
     err = event_queue_init();

--- a/main/main.c
+++ b/main/main.c
@@ -63,6 +63,14 @@ void app_main(void)
         return;
     }
 
+    // TODO: Temporary fixture schedule for store integration testing.
+    // Remove this before using API-provided schedules or real hardware.
+    err = schedule_store_apply_fixture();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to apply fixture schedule");
+        return;
+    }
+
     // Initialize event queue and check for errors
     err = event_queue_init();
     if (err != ESP_OK) {

--- a/main/main.c
+++ b/main/main.c
@@ -3,6 +3,7 @@
 #include "storage_nvs.h"
 #include "rtc_driver.h"
 #include "schedule.h"
+#include "schedule_store.h"
 #include "dispense.h"
 #include "motor_task.h"
 #include "event_queue.h"
@@ -52,6 +53,13 @@ void app_main(void)
     err = dispense_init();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to initialize dispense");
+        return;
+    }
+
+    // Initialize schedule store for API-provided schedules
+    err = schedule_store_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize schedule store");
         return;
     }
 


### PR DESCRIPTION
## 📌 Related Issue

Closes #37

## 🚀 Description

- Add a RAM-backed schedule store and fixture apply path for API-ready schedule data.
- Update `schedule_task` to read schedule snapshots instead of generating current-time test slots.
- Add a refresh request hook for future `SCHEDULE_UPDATED` handling without running dispense directly.

## 📢 Review Point

- Check that `schedule_task` uses copied snapshots and does not race schedule updates.
- Check that duplicate slot triggers reset only on schedule version change or day change.
- Check that the temporary fixture path is safe to remove before real API/hardware use.

## 📚 Etc

### Verification Criteria
- Fixture schedule logs show 8 active slots with version 1.
- `schedule_task` logs `Loaded schedule snapshot: count=8 version=1` after RTC sync.
- Matching fixture times enqueue one dispense event per slot and flow through dummy motor/intake.
- Medication event POST completes with HTTP 200 in the log-backed test flow.

### Verification Evidence
- Device logs show the schedule store initialized and applied 8 fixture slots with `version=1`.
- After RTC synchronization, `schedule_task` loaded the RAM schedule snapshot with `count=8 version=1`.
- Matching fixture times triggered dispense enqueue for the expected slot numbers.
- Dummy motor flow processed the queued slot events through open, intake wait, and close.
- Medication status events were sent to the server and completed with HTTP 200.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/6efbfa72-a137-4e62-b029-5d8e17b80ed0" />
<img width="700" alt="Screenshot 2026-05-30 201047" src="https://github.com/user-attachments/assets/46123536-2ab6-4b94-9b6b-df5640725e03" />
<img width="700" alt="Screenshot 2026-05-30 201100" src="https://github.com/user-attachments/assets/af325c4f-e000-4ffc-8488-8fbbf218ea1d" />
