### PR TITLE
Feat: Add slot hardware mapping configuration

### DIFF
--- a/components/slot_map/CMakeLists.txt
+++ b/components/slot_map/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "slot_map.c"
+    INCLUDE_DIRS "include"
+    REQUIRES esp_driver_gpio)

--- a/components/slot_map/include/slot_map.h
+++ b/components/slot_map/include/slot_map.h
@@ -1,0 +1,22 @@
+#ifndef SLOT_MAP_H
+#define SLOT_MAP_H
+
+#include <stdint.h>
+#include "driver/gpio.h"
+#include "esp_err.h"
+
+#define SLOT_COUNT 8
+
+typedef struct {
+    gpio_num_t servo_gpio;
+    uint8_t    ads1115_addr;
+    uint8_t    ads1115_channel;
+} SlotHwConfig;
+
+/**
+ * Returns the hardware config for the given slot_id (1-based, 1..SLOT_COUNT).
+ * Returns ESP_ERR_INVALID_ARG if slot_id is out of range.
+ */
+esp_err_t slot_map_get(uint8_t slot_id, const SlotHwConfig **out);
+
+#endif // SLOT_MAP_H

--- a/components/slot_map/slot_map.c
+++ b/components/slot_map/slot_map.c
@@ -1,0 +1,21 @@
+#include "slot_map.h"
+
+static const SlotHwConfig s_slot_map[SLOT_COUNT] = {
+    {GPIO_NUM_13, 0x48, 0}, // slot_id=1
+    {GPIO_NUM_14, 0x48, 1}, // slot_id=2
+    {GPIO_NUM_15, 0x48, 2}, // slot_id=3
+    {GPIO_NUM_16, 0x48, 3}, // slot_id=4
+    {GPIO_NUM_17, 0x49, 0}, // slot_id=5
+    {GPIO_NUM_18, 0x49, 1}, // slot_id=6
+    {GPIO_NUM_19, 0x49, 2}, // slot_id=7
+    {GPIO_NUM_23, 0x49, 3}, // slot_id=8
+};
+
+esp_err_t slot_map_get(uint8_t slot_id, const SlotHwConfig **out)
+{
+    if (slot_id < 1 || slot_id > SLOT_COUNT || out == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    *out = &s_slot_map[slot_id - 1];
+    return ESP_OK;
+}


### PR DESCRIPTION
## 📌 Related Issue

Closes #39

## 🚀 Description

- Add `slot_map` component providing a centralized hardware mapping table for all 8 slots.
- Each slot entry binds a servo GPIO pin and an ADS1115 I2C address + channel.
- Exposes `slot_map_get(slot_id, &out)` as the single public API for lookup (1-based slot_id, returns `ESP_ERR_INVALID_ARG` for out-of-range input).
- No servo control, sensor reading, or intake detection logic is included.

## 📢 Review Point

- `slot_map_get()` validates both `slot_id` range and `out == NULL`; no other entry point touches the table.
- Table is `static const`, so no runtime mutation is possible.
- `REQUIRES esp_driver_gpio` instead of the deprecated `driver` component (ESP-IDF v5+).

## 📚 Etc

### Verification Criteria
- Build succeeds with the new `slot_map` component.
- `slot_map_get(1..8, &out)` returns `ESP_OK` and correct `servo_gpio` / `ads1115_addr` / `ads1115_channel` for each slot.
- `slot_map_get(0, &out)` and `slot_map_get(9, &out)` return `ESP_ERR_INVALID_ARG`.
- No existing component references hardcoded slot-to-GPIO mappings.

### Verification Evidence
- Log screenshot: to be attached