### PR TITLE
Feat: Implement servo motor control driver

### DIFF
--- a/components/motor/CMakeLists.txt
+++ b/components/motor/CMakeLists.txt
@@ -1,7 +1,8 @@
 idf_component_register(
-    SRCS "motor_task.c" "servo_driver_factory.c" "dummy_servo_driver.c"
+    SRCS "motor_task.c" "servo_driver_factory.c" "dummy_servo_driver.c" "ledc_servo_driver.c"
     INCLUDE_DIRS "include"
-    REQUIRES dispense intake event_queue)
+    REQUIRES dispense intake event_queue
+    PRIV_REQUIRES slot_map esp_driver_ledc)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/motor/include/ledc_servo_driver.h
+++ b/components/motor/include/ledc_servo_driver.h
@@ -1,0 +1,11 @@
+#ifndef LEDC_SERVO_DRIVER_H
+#define LEDC_SERVO_DRIVER_H
+
+#include "servo_driver.h"
+#include "esp_err.h"
+
+esp_err_t ledc_servo_driver_init(void);
+
+extern const ServoDriver LEDC_SERVO_DRIVER;
+
+#endif // LEDC_SERVO_DRIVER_H

--- a/components/motor/include/motor_task.h
+++ b/components/motor/include/motor_task.h
@@ -2,10 +2,12 @@
 #define MOTOR_TASK_H
 
 #include "freertos/FreeRTOS.h"
+#include "esp_err.h"
 
 #define MOTOR_TASK_STACK_SIZE 4096
 #define MOTOR_TASK_PRIORITY 5
 
+esp_err_t motor_init(void);
 void motor_task(void *arg);
 BaseType_t create_motor_task(void);
 

--- a/components/motor/ledc_servo_driver.c
+++ b/components/motor/ledc_servo_driver.c
@@ -1,0 +1,124 @@
+#include "ledc_servo_driver.h"
+#include "slot_map.h"
+#include "driver/ledc.h"
+#include "esp_log.h"
+
+static const char *TAG = "ledc_servo";
+
+#define SERVO_TIMER           LEDC_TIMER_0
+#define SERVO_MODE            LEDC_LOW_SPEED_MODE
+#define SERVO_FREQ_HZ         50
+#define SERVO_RESOLUTION      LEDC_TIMER_14_BIT
+#define SERVO_PERIOD_US       20000
+#define SERVO_MIN_PULSE_US    500
+#define SERVO_MAX_PULSE_US    2500
+
+#define SERVO_OPEN_ANGLE_DEG  90
+#define SERVO_CLOSE_ANGLE_DEG 0
+
+static ledc_channel_t s_channels[SLOT_COUNT];
+
+// Convert angle in degree to duty cycle value for LEDC
+static uint32_t angle_to_duty(uint8_t angle_deg)
+{
+    uint32_t pulse_us = SERVO_MIN_PULSE_US +
+        (uint32_t)angle_deg * (SERVO_MAX_PULSE_US - SERVO_MIN_PULSE_US) / 180;
+    return (pulse_us * (1u << SERVO_RESOLUTION)) / SERVO_PERIOD_US;
+}
+
+esp_err_t ledc_servo_driver_init(void)
+{
+    ledc_timer_config_t timer_cfg = {
+        .speed_mode      = SERVO_MODE,
+        .timer_num       = SERVO_TIMER,
+        .duty_resolution = SERVO_RESOLUTION,
+        .freq_hz         = SERVO_FREQ_HZ,
+        .clk_cfg         = LEDC_AUTO_CLK,
+    };
+    esp_err_t err = ledc_timer_config(&timer_cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "LEDC timer init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    uint32_t close_duty = angle_to_duty(SERVO_CLOSE_ANGLE_DEG);
+
+    // Initialize LEDC channels for all slots
+    for (uint8_t slot_id = 1; slot_id <= SLOT_COUNT; slot_id++) {
+        const SlotHwConfig *cfg = NULL;
+        err = slot_map_get(slot_id, &cfg);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "slot_map_get failed: slot=%d", slot_id);
+            return err;
+        }
+
+        ledc_channel_t ch = (ledc_channel_t)(slot_id - 1);
+        s_channels[slot_id - 1] = ch;
+
+        ledc_channel_config_t ch_cfg = {
+            .gpio_num   = cfg->servo_gpio,
+            .speed_mode = SERVO_MODE,
+            .channel    = ch,
+            .intr_type  = LEDC_INTR_DISABLE,
+            .timer_sel  = SERVO_TIMER,
+            .duty       = close_duty,
+            .hpoint     = 0,
+        };
+        err = ledc_channel_config(&ch_cfg);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "LEDC channel init failed: slot=%d gpio=%d", slot_id, cfg->servo_gpio);
+            return err;
+        }
+        ESP_LOGI(TAG, "servo init: slot=%d gpio=%d ch=%d", slot_id, cfg->servo_gpio, ch);
+    }
+
+    ESP_LOGI(TAG, "all %d servo channels initialized", SLOT_COUNT);
+    return ESP_OK;
+}
+
+static esp_err_t ledc_open(uint8_t slot_id)
+{
+    if (slot_id < 1 || slot_id > SLOT_COUNT) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    ledc_channel_t ch = s_channels[slot_id - 1];
+    uint32_t duty = angle_to_duty(SERVO_OPEN_ANGLE_DEG);
+    esp_err_t err = ledc_set_duty(SERVO_MODE, ch, duty);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "servo open set_duty failed: slot=%d", slot_id);
+        return err;
+    }
+    err = ledc_update_duty(SERVO_MODE, ch);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "servo open update_duty failed: slot=%d", slot_id);
+        return err;
+    }
+    ESP_LOGI(TAG, "servo open: slot=%d ch=%d duty=%u", slot_id, ch, (unsigned)duty);
+    return ESP_OK;
+}
+
+static esp_err_t ledc_close(uint8_t slot_id)
+{
+    if (slot_id < 1 || slot_id > SLOT_COUNT) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    ledc_channel_t ch = s_channels[slot_id - 1];
+    uint32_t duty = angle_to_duty(SERVO_CLOSE_ANGLE_DEG);
+    esp_err_t err = ledc_set_duty(SERVO_MODE, ch, duty);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "servo close set_duty failed: slot=%d", slot_id);
+        return err;
+    }
+    err = ledc_update_duty(SERVO_MODE, ch);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "servo close update_duty failed: slot=%d", slot_id);
+        return err;
+    }
+    ESP_LOGI(TAG, "servo close: slot=%d ch=%d duty=%u", slot_id, ch, (unsigned)duty);
+    return ESP_OK;
+}
+
+const ServoDriver LEDC_SERVO_DRIVER = {
+    .open  = ledc_open,
+    .close = ledc_close,
+};

--- a/components/motor/motor_task.c
+++ b/components/motor/motor_task.c
@@ -52,8 +52,12 @@ void motor_task(void *arg) {
         if (xQueueReceive(dispense_queue, &event, portMAX_DELAY) == pdTRUE) {
             ESP_LOGI(TAG, "Processing dispense event for slot ID: %d", event.slot_id);
 
-            // Open the servo to dispense medication
-            servo->open(event.slot_id);
+            esp_err_t open_err = servo->open(event.slot_id);
+            if (open_err != ESP_OK) {
+                ESP_LOGE(TAG, "servo open failed for slot %d: %s", event.slot_id, esp_err_to_name(open_err));
+                // TODO: open failure means dispense never started — add a device fault event type to report to server
+                continue;
+            }
 
             // Wait for intake detection with a timeout
             IntakeResult result = detector->wait(event.slot_id, pdMS_TO_TICKS(3000)); // 3-second timeout for testing
@@ -77,7 +81,11 @@ void motor_task(void *arg) {
                     break;
             }
 
-            servo->close(event.slot_id);
+            esp_err_t close_err = servo->close(event.slot_id);
+            if (close_err != ESP_OK) {
+                ESP_LOGE(TAG, "servo close failed for slot %d: %s", event.slot_id, esp_err_to_name(close_err));
+                // TODO: if close fails while another slot dispenses, medication mixing is possible — response strategy TBD
+            }
 
             if (is_event_pushed) {
                 MedicationEvent medication_event = {

--- a/components/motor/motor_task.c
+++ b/components/motor/motor_task.c
@@ -12,6 +12,15 @@ static const char *TAG = "motor";
 static int64_t get_timestamp_ms(void);
 static bool is_time_synced(void);
 
+esp_err_t motor_init(void) {
+    const ServoDriver *servo = get_default_servo_driver();
+    if (servo == NULL) {
+        ESP_LOGE(TAG, "servo driver init failed");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
 BaseType_t create_motor_task(void) {
     return xTaskCreate(
         motor_task,

--- a/components/motor/servo_driver_factory.c
+++ b/components/motor/servo_driver_factory.c
@@ -1,6 +1,31 @@
 #include "servo_driver_factory.h"
+
+#ifdef CI_BUILD
 #include "dummy_servo_driver.h"
 
+// Get the default servo driver instance, which is a dummy driver in CI build
 const ServoDriver *get_default_servo_driver(void) {
     return &DUMMY_SERVO_DRIVER;
 }
+
+#else
+#include "ledc_servo_driver.h"
+#include "esp_log.h"
+
+static const char *TAG = "servo_factory";
+
+// Get the default servo driver instance, which is initialized on first call
+const ServoDriver *get_default_servo_driver(void) {
+    static bool s_initialized = false;
+    if (!s_initialized) {
+        esp_err_t err = ledc_servo_driver_init();
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "ledc_servo_driver_init failed: %s", esp_err_to_name(err));
+            return NULL;
+        }
+        s_initialized = true;
+    }
+    return &LEDC_SERVO_DRIVER;
+}
+
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -79,6 +79,13 @@ void app_main(void)
         return;
     }
     
+    // Initialize motor subsystem (servo driver) before starting the task
+    err = motor_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize motor");
+        return;
+    }
+
     // Create the motor task
     BaseType_t motor_task_created = create_motor_task();
 


### PR DESCRIPTION
## 📌 Related Issue

Closes #40

## 🚀 Description

- Added `ledc_servo_driver` using ESP-IDF LEDC PWM API (50 Hz, 14-bit resolution, LEDC_TIMER_0, low-speed mode).
- All 8 servo GPIOs are initialized from `slot_map` at startup; each slot maps to a dedicated LEDC channel (ch0–ch7).
- `open` moves the servo to 90° and `close` returns it to 0° by writing the computed duty cycle via `ledc_set_duty` + `ledc_update_duty`.
- `angle_to_duty()` converts degrees to LEDC ticks using the 0.5–2.5 ms SG90 pulse range.
- `servo_driver_factory` returns `LEDC_SERVO_DRIVER` on real builds and `DUMMY_SERVO_DRIVER` on `CI_BUILD`; init is guarded by a `static bool` to prevent duplicate initialization.

## 📢 Review Point

- **LEDC channel exhaustion**: 8 slots consume LEDC channels 0–7 in `LEDC_LOW_SPEED_MODE`. If any other peripheral later shares the same timer or channels, there will be a conflict. Currently no other LEDC usage exists, but worth flagging.
- **`s_channels` not initialized before first open/close**: `s_channels` is populated inside `ledc_servo_driver_init()`. If `open` or `close` is called before init (e.g., `get_default_servo_driver()` returns a stale pointer), channel 0 is used silently. The factory's `static bool` guard prevents this in normal flow, but it is not thread-safe across concurrent first calls.
- **Init failure leaves partial channel state**: if `ledc_channel_config` fails mid-loop (e.g., slot 4), channels 0–2 are already configured and active. There is no rollback; the factory returns `NULL` and `motor_task` exits, but the partially initialized LEDC state remains.
- **`angle_to_duty` integer truncation**: intermediate division uses integer arithmetic (`/ 180`), which truncates. For the two angles used (0° and 90°) the values are correct; edge-case angles near 180° may drift slightly but are not used today.

## 📚 Etc

### Verification Criteria
- Boot log shows `servo init: slot=N gpio=XX ch=N` for slots 1–8 followed by `all 8 servo channels initialized`.
- `servo open: slot=1 ch=0 duty=1228` appears when slot 1 is triggered.
- `servo close: slot=1 ch=0 duty=409` appears after intake wait completes.
- No open/close log appears for slots other than the triggered slot.
- CI build compiles without error and `motor_task` log shows dummy driver messages.

### Verification Evidence
- All 8 channels initialized at boot
- Servo open: duty=1228 (90°) confirmed for slot 4, 5
- Servo close: duty=409 (0°) confirmed for slots 4, 5
- Independent slot operation (only matched slots triggered)
- Full pipeline functional: schedule → dispense → motor → servo → event → HTTP
<img width="1302" height="943" alt="image" src="https://github.com/user-attachments/assets/328fc1da-3950-48d7-a443-ce887047943c" />
<img width="1299" height="700" alt="image" src="https://github.com/user-attachments/assets/f0bbf8aa-9c5e-4145-b1f0-46db1ab7e0aa" />
<img width="1277" height="397" alt="image" src="https://github.com/user-attachments/assets/27ab2f12-5cec-43dd-931e-2db467a0796b" />
