### PR TITLE
Fix: Smooth servo motion with LEDC fade and extend intake timeout #46

### DIFF
--- a/components/motor/ledc_servo_driver.c
+++ b/components/motor/ledc_servo_driver.c
@@ -15,6 +15,7 @@ static const char *TAG = "ledc_servo";
 
 #define SERVO_OPEN_ANGLE_DEG  90
 #define SERVO_CLOSE_ANGLE_DEG 0
+#define SERVO_FADE_MS         500
 
 static ledc_channel_t s_channels[SLOT_COUNT];
 
@@ -69,10 +70,16 @@ esp_err_t ledc_servo_driver_init(void)
             ESP_LOGE(TAG, "LEDC channel init failed: slot=%d gpio=%d", slot_id, cfg->servo_gpio);
             return err;
         }
-        ESP_LOGI(TAG, "servo init: slot=%d gpio=%d ch=%d", slot_id, cfg->servo_gpio, ch);
+        ESP_LOGI(TAG, "servo init: slot=%d gpio=%d ch=%d duty=%u", slot_id, cfg->servo_gpio, ch, (unsigned)close_duty);
     }
 
-    ESP_LOGI(TAG, "all %d servo channels initialized", SLOT_COUNT);
+    esp_err_t fade_err = ledc_fade_func_install(0);
+    if (fade_err != ESP_OK && fade_err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "fade func install failed: %s", esp_err_to_name(fade_err));
+        return fade_err;
+    }
+
+    ESP_LOGI(TAG, "all %d servo channels initialized to close angle", SLOT_COUNT);
     return ESP_OK;
 }
 
@@ -83,14 +90,14 @@ static esp_err_t ledc_open(uint8_t slot_id)
     }
     ledc_channel_t ch = s_channels[slot_id - 1];
     uint32_t duty = angle_to_duty(SERVO_OPEN_ANGLE_DEG);
-    esp_err_t err = ledc_set_duty(SERVO_MODE, ch, duty);
+    esp_err_t err = ledc_set_fade_with_time(SERVO_MODE, ch, duty, SERVO_FADE_MS);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "servo open set_duty failed: slot=%d", slot_id);
+        ESP_LOGE(TAG, "servo open set_fade failed: slot=%d", slot_id);
         return err;
     }
-    err = ledc_update_duty(SERVO_MODE, ch);
+    err = ledc_fade_start(SERVO_MODE, ch, LEDC_FADE_WAIT_DONE);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "servo open update_duty failed: slot=%d", slot_id);
+        ESP_LOGE(TAG, "servo open fade_start failed: slot=%d", slot_id);
         return err;
     }
     ESP_LOGI(TAG, "servo open: slot=%d ch=%d duty=%u", slot_id, ch, (unsigned)duty);
@@ -104,14 +111,14 @@ static esp_err_t ledc_close(uint8_t slot_id)
     }
     ledc_channel_t ch = s_channels[slot_id - 1];
     uint32_t duty = angle_to_duty(SERVO_CLOSE_ANGLE_DEG);
-    esp_err_t err = ledc_set_duty(SERVO_MODE, ch, duty);
+    esp_err_t err = ledc_set_fade_with_time(SERVO_MODE, ch, duty, SERVO_FADE_MS);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "servo close set_duty failed: slot=%d", slot_id);
+        ESP_LOGE(TAG, "servo close set_fade failed: slot=%d", slot_id);
         return err;
     }
-    err = ledc_update_duty(SERVO_MODE, ch);
+    err = ledc_fade_start(SERVO_MODE, ch, LEDC_FADE_WAIT_DONE);
     if (err != ESP_OK) {
-        ESP_LOGE(TAG, "servo close update_duty failed: slot=%d", slot_id);
+        ESP_LOGE(TAG, "servo close fade_start failed: slot=%d", slot_id);
         return err;
     }
     ESP_LOGI(TAG, "servo close: slot=%d ch=%d duty=%u", slot_id, ch, (unsigned)duty);

--- a/components/motor/motor_task.c
+++ b/components/motor/motor_task.c
@@ -68,8 +68,8 @@ void motor_task(void *arg) {
                 continue;
             }
 
-            // Wait for intake detection with a timeout
-            IntakeResult result = detector->wait(event.slot_id, pdMS_TO_TICKS(3000)); // 3-second timeout for testing
+            // servo->open blocks until fade completes; give the user time to take medication
+            IntakeResult result = detector->wait(event.slot_id, pdMS_TO_TICKS(15000));
 
             bool is_event_pushed = false;
             MedicationStatus status;


### PR DESCRIPTION
## 📌 Related Issue

Closes #46

## 🚀 Description

- Replace instantaneous duty update (`ledc_set_duty` + `ledc_update_duty`) with `ledc_set_fade_with_time` + `ledc_fade_start(LEDC_FADE_WAIT_DONE)` for both open and close.
- Added `SERVO_FADE_MS 500`: servo travels from 0° to 90° (or back) over 500 ms, giving a natural lid-opening feel.
- Installed LEDC fade ISR via `ledc_fade_func_install(0)` at the end of `ledc_servo_driver_init`; `ESP_ERR_INVALID_STATE` is ignored to guard against double-init.
- Boot-time close initialization log now includes the computed `close_duty` value for easier verification.
- Extended `detector->wait` timeout from 3 000 ms to 15 000 ms. Since `servo->open` now blocks until the fade completes, the timeout represents pure user-action time after the lid is fully open.

## 📢 Review Point

- `LEDC_FADE_WAIT_DONE` blocks the `motor_task` for 500 ms on every open/close call. This is intentional — the task must not start intake detection before the lid reaches the open position. Verify that the task watchdog threshold (default 5 s) is not exceeded.
- `ledc_fade_func_install` installs an LEDC interrupt. Confirm no other component in this project calls it separately, which would trigger `ESP_ERR_INVALID_STATE` on the first call.
- `dummy_intake_detector` simulates the full 15 s timeout via `vTaskDelay`, so a complete test cycle now takes ~16 s. This is expected behavior until the ADS1115 detector is wired in.

## 📚 Etc

### Verification Criteria
- Boot log shows `servo init: slot=1 gpio=13 ch=0 duty=<N>` for each slot with no LEDC errors.
- Boot log shows `all 8 servo channels initialized to close angle`.
- On dispense trigger: `servo open` log appears ~500 ms after the open command is issued (not immediately).
- `servo close` log appears ~500 ms after close is called.
- After close, no jitter or repeated movement is observed.
- `motor_task` logs `MISSED` event ~16 s after dispense trigger (15 s wait + 500 ms close fade).

### Verification Evidence
<img width="1508" height="584" alt="Screenshot 2026-05-31 210139" src="https://github.com/user-attachments/assets/ff628c14-8d77-42e2-b997-2c749979b039" />
모터 자알 ~ 돌아간다