### PR TITLE
Test: Validate operation of all 8 servo motors

### DIFF
--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -16,14 +16,14 @@ static bool s_refresh_pending = false;
 static uint32_t s_refresh_request_count = 0;
 
 static const SlotEntry s_fixture_slots[] = {
-    { .slot_id = 1, .hour = 7, .minute = 0, .triggered = false },
-    { .slot_id = 2, .hour = 8, .minute = 30, .triggered = false },
-    { .slot_id = 3, .hour = 10, .minute = 0, .triggered = false },
-    { .slot_id = 4, .hour = 20, .minute = 5, .triggered = false },
-    { .slot_id = 5, .hour = 20, .minute = 10, .triggered = false },
-    { .slot_id = 6, .hour = 20, .minute = 30, .triggered = false },
-    { .slot_id = 7, .hour = 21, .minute = 0, .triggered = false },
-    { .slot_id = 8, .hour = 22, .minute = 30, .triggered = false },
+    { .slot_id = 1, .hour = 22, .minute = 12, .triggered = false },
+    { .slot_id = 2, .hour = 22, .minute = 13, .triggered = false },
+    { .slot_id = 3, .hour = 22, .minute = 14, .triggered = false },
+    { .slot_id = 4, .hour = 22, .minute = 15, .triggered = false },
+    { .slot_id = 5, .hour = 22, .minute = 16, .triggered = false },
+    { .slot_id = 6, .hour = 22, .minute = 17, .triggered = false },
+    { .slot_id = 7, .hour = 22, .minute = 18, .triggered = false },
+    { .slot_id = 8, .hour = 22, .minute = 19, .triggered = false },
 };
 
 static void log_applied_slots(const SlotEntry *slots, size_t count, uint32_t version)


### PR DESCRIPTION
## 📌 Related Issue

Closes #48

## 🚀 Description

- Updated fixture slots to 8 consecutive 1-minute intervals (22:12–22:19) to trigger all slots in sequence within a single test session.
- No servo driver, motor task, or intake detector logic was modified.

## 📢 Review Point

- Fixture slot times are test-only; they are not user-facing schedule data and will be replaced by API-provided schedules once the server integration is complete.
- Each slot fires 1 minute apart — verify that no slot is skipped or double-triggered across the midnight boundary if a session runs late.

## 📚 Etc

### Verification Criteria
- Boot log shows `servo init: slot=X gpio=Y ch=Z duty=N` for all 8 slots with no LEDC errors.
- Boot log shows `all 8 servo channels initialized to close angle`.
- Each slot triggers `Processing dispense event for slot ID: X` in order (1–8) at the scheduled minute.
- `servo open` and `servo close` logs appear for each slot with the correct slot ID and no cross-slot mismatch.
- No unintended repeated movement or jitter is observed on any servo.

### Verification Evidence
1. 부팅 시 모터 초기화 (8 채널)
<img width="1543" height="1213" alt="Screenshot 2026-05-31 222143" src="https://github.com/user-attachments/assets/8470b8b7-9aaa-48dc-b75b-88f220e87f2a" />
2. 8개 채널 디스펜스 사이클 (open $\to$ close)
<img width="1498" height="1096" alt="Screenshot 2026-05-31 221343" src="https://github.com/user-attachments/assets/574d7f6d-9fe7-41a1-b888-4da4e03ca835" />
<img width="1488" height="1150" alt="Screenshot 2026-05-31 222106" src="https://github.com/user-attachments/assets/f4ec71cc-9dbb-4998-86a3-6f1a43c9f81a" />
<img width="1491" height="1310" alt="Screenshot 2026-05-31 222121" src="https://github.com/user-attachments/assets/9b8b451c-3ce1-45cd-a2ac-3934f2d4dca5" />

모터 자알~ 돌아간다.