### PR TITLE
Feat: Implement ADS1115 intake sensor interface

### DIFF
--- a/components/ads1115_driver/CMakeLists.txt
+++ b/components/ads1115_driver/CMakeLists.txt
@@ -1,0 +1,12 @@
+idf_component_register(
+    SRCS "ads1115.c"
+    INCLUDE_DIRS "include"
+    PRIV_REQUIRES esp_driver_i2c freertos)
+if(CI_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
+    target_compile_options(${COMPONENT_LIB} PRIVATE
+        -Wno-unused-function
+        -Wno-unused-variable
+        -Wno-unused-parameter
+    )
+endif()

--- a/components/ads1115_driver/ads1115.c
+++ b/components/ads1115_driver/ads1115.c
@@ -102,9 +102,21 @@ esp_err_t ads1115_detect(uint8_t addr, bool *found)
     if (s_bus == NULL) return ESP_ERR_INVALID_STATE;
 
     esp_err_t err = i2c_master_probe(s_bus, addr, 50);
-    *found = (err == ESP_OK);
-    ESP_LOGI(TAG, "detect 0x%02x: %s", addr, *found ? "found" : "not found");
-    return ESP_OK;
+    if (err == ESP_OK) {
+        *found = true;
+        ESP_LOGI(TAG, "detect 0x%02x: found", addr);
+        return ESP_OK;
+    }
+
+    if (err == ESP_ERR_NOT_FOUND) {
+        *found = false;
+        ESP_LOGI(TAG, "detect 0x%02x: not found", addr);
+        return ESP_OK;
+    }
+
+    *found = false;
+    ESP_LOGE(TAG, "detect 0x%02x failed: %s", addr, esp_err_to_name(err));
+    return err;
 }
 
 esp_err_t ads1115_read_channel(uint8_t addr, uint8_t channel, int16_t *out)

--- a/components/ads1115_driver/ads1115.c
+++ b/components/ads1115_driver/ads1115.c
@@ -1,0 +1,138 @@
+#include "ads1115.h"
+#include "driver/i2c_master.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+static const char *TAG = "ads1115";
+
+#define ADS1115_I2C_PORT    I2C_NUM_0
+#define ADS1115_I2C_SPEED   100000
+
+#define ADS1115_REG_CONVERSION  0x00
+#define ADS1115_REG_CONFIG      0x01
+
+// 128 SPS = 7.8 ms per conversion; 15 ms gives enough margin.
+#define ADS1115_CONV_WAIT_MS    15
+
+// Config high byte: OS=1, MUX=single-ended, PGA=+/-2.048 V, MODE=single-shot.
+// Single-ended MUX values are ch0=100, ch1=101, ch2=110, ch3=111.
+#define ADS1115_CONFIG_HI_BASE  0xC5
+// Config low byte: DR=128 SPS, comparator disabled.
+#define ADS1115_CONFIG_LO       0x83
+
+static i2c_master_bus_handle_t s_bus = NULL;
+// Index 0 maps to 0x48, index 1 maps to 0x49.
+static i2c_master_dev_handle_t s_devs[2] = {NULL, NULL};
+
+static void cleanup_bus(void)
+{
+    for (int i = 0; i < 2; i++) {
+        if (s_devs[i] != NULL) {
+            esp_err_t err = i2c_master_bus_rm_device(s_devs[i]);
+            if (err != ESP_OK) {
+                ESP_LOGW(TAG, "remove device %d failed: %s", i, esp_err_to_name(err));
+                continue;
+            }
+            s_devs[i] = NULL;
+        }
+    }
+
+    if (s_bus != NULL) {
+        esp_err_t err = i2c_del_master_bus(s_bus);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "delete bus failed: %s", esp_err_to_name(err));
+            return;
+        }
+        s_bus = NULL;
+    }
+}
+
+static int addr_to_idx(uint8_t addr)
+{
+    if (addr == ADS1115_ADDR_LO) return 0;
+    if (addr == ADS1115_ADDR_HI) return 1;
+    return -1;
+}
+
+esp_err_t ads1115_bus_init(int sda_gpio, int scl_gpio)
+{
+    if (s_bus != NULL) {
+        ESP_LOGW(TAG, "bus already initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    i2c_master_bus_config_t bus_cfg = {
+        .clk_source             = I2C_CLK_SRC_DEFAULT,
+        .i2c_port               = ADS1115_I2C_PORT,
+        .scl_io_num             = scl_gpio,
+        .sda_io_num             = sda_gpio,
+        .glitch_ignore_cnt      = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    esp_err_t err = i2c_new_master_bus(&bus_cfg, &s_bus);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "bus init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    uint8_t addrs[2] = {ADS1115_ADDR_LO, ADS1115_ADDR_HI};
+    for (int i = 0; i < 2; i++) {
+        i2c_device_config_t dev_cfg = {
+            .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+            .device_address  = addrs[i],
+            .scl_speed_hz    = ADS1115_I2C_SPEED,
+        };
+        err = i2c_master_bus_add_device(s_bus, &dev_cfg, &s_devs[i]);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "add device 0x%02x failed: %s", addrs[i], esp_err_to_name(err));
+            cleanup_bus();
+            return err;
+        }
+    }
+
+    ESP_LOGI(TAG, "I2C bus ready: sda=%d scl=%d", sda_gpio, scl_gpio);
+    return ESP_OK;
+}
+
+esp_err_t ads1115_detect(uint8_t addr, bool *found)
+{
+    if (found == NULL) return ESP_ERR_INVALID_ARG;
+    if (addr_to_idx(addr) < 0) return ESP_ERR_INVALID_ARG;
+    if (s_bus == NULL) return ESP_ERR_INVALID_STATE;
+
+    esp_err_t err = i2c_master_probe(s_bus, addr, 50);
+    *found = (err == ESP_OK);
+    ESP_LOGI(TAG, "detect 0x%02x: %s", addr, *found ? "found" : "not found");
+    return ESP_OK;
+}
+
+esp_err_t ads1115_read_channel(uint8_t addr, uint8_t channel, int16_t *out)
+{
+    if (out == NULL || channel >= ADS1115_CHANNEL_COUNT) return ESP_ERR_INVALID_ARG;
+    int idx = addr_to_idx(addr);
+    if (idx < 0) return ESP_ERR_INVALID_ARG;
+    if (s_devs[idx] == NULL) return ESP_ERR_INVALID_STATE;
+
+    uint8_t config_hi = (uint8_t)(ADS1115_CONFIG_HI_BASE | (channel << 4));
+    uint8_t write_buf[3] = {ADS1115_REG_CONFIG, config_hi, ADS1115_CONFIG_LO};
+
+    esp_err_t err = i2c_master_transmit(s_devs[idx], write_buf, sizeof(write_buf), 50);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "config write failed: addr=0x%02x ch=%d: %s", addr, channel, esp_err_to_name(err));
+        return err;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(ADS1115_CONV_WAIT_MS));
+
+    uint8_t reg = ADS1115_REG_CONVERSION;
+    uint8_t read_buf[2] = {0};
+    err = i2c_master_transmit_receive(s_devs[idx], &reg, 1, read_buf, 2, 50);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "conversion read failed: addr=0x%02x ch=%d: %s", addr, channel, esp_err_to_name(err));
+        return err;
+    }
+
+    *out = (int16_t)((read_buf[0] << 8) | read_buf[1]);
+    return ESP_OK;
+}

--- a/components/ads1115_driver/include/ads1115.h
+++ b/components/ads1115_driver/include/ads1115.h
@@ -1,0 +1,30 @@
+#ifndef ADS1115_H
+#define ADS1115_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_err.h"
+
+#define ADS1115_ADDR_LO       0x48
+#define ADS1115_ADDR_HI       0x49
+#define ADS1115_CHANNEL_COUNT 4
+
+/**
+ * Initialize the I2C master bus. Must be called once before ads1115_detect or
+ * ads1115_read_channel.
+ */
+esp_err_t ads1115_bus_init(int sda_gpio, int scl_gpio);
+
+/**
+ * Probe the bus to check whether an ADS1115 device is present at addr.
+ * addr must be ADS1115_ADDR_LO or ADS1115_ADDR_HI.
+ */
+esp_err_t ads1115_detect(uint8_t addr, bool *found);
+
+/**
+ * Trigger a single-shot conversion on channel (0..3) and return the raw
+ * signed 16-bit result. Returns ESP_ERR_INVALID_ARG for out-of-range inputs.
+ */
+esp_err_t ads1115_read_channel(uint8_t addr, uint8_t channel, int16_t *out);
+
+#endif // ADS1115_H

--- a/components/ads1115_driver/include/ads1115.h
+++ b/components/ads1115_driver/include/ads1115.h
@@ -9,22 +9,13 @@
 #define ADS1115_ADDR_HI       0x49
 #define ADS1115_CHANNEL_COUNT 4
 
-/**
- * Initialize the I2C master bus. Must be called once before ads1115_detect or
- * ads1115_read_channel.
- */
+// Initialize the I2C master bus before detect or read calls.
 esp_err_t ads1115_bus_init(int sda_gpio, int scl_gpio);
 
-/**
- * Probe the bus to check whether an ADS1115 device is present at addr.
- * addr must be ADS1115_ADDR_LO or ADS1115_ADDR_HI.
- */
+// Probe the bus for ADS1115_ADDR_LO or ADS1115_ADDR_HI.
 esp_err_t ads1115_detect(uint8_t addr, bool *found);
 
-/**
- * Trigger a single-shot conversion on channel (0..3) and return the raw
- * signed 16-bit result. Returns ESP_ERR_INVALID_ARG for out-of-range inputs.
- */
+// Trigger a single-shot conversion on channel 0..3 and return the raw value.
 esp_err_t ads1115_read_channel(uint8_t addr, uint8_t channel, int16_t *out);
 
 #endif // ADS1115_H

--- a/components/intake/CMakeLists.txt
+++ b/components/intake/CMakeLists.txt
@@ -10,3 +10,6 @@ if(CI_BUILD)
         -Wno-unused-parameter
     )
 endif()
+if(TEST_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TEST_BUILD)
+endif()

--- a/components/intake/CMakeLists.txt
+++ b/components/intake/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "dummy_intake_detector.c" "intake_detector_factory.c" "intake.c"
     INCLUDE_DIRS "include"
-    REQUIRES ads1115_driver esp_driver_gpio)
+    REQUIRES ads1115_driver esp_driver_gpio slot_map)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/intake/CMakeLists.txt
+++ b/components/intake/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "dummy_intake_detector.c" "intake_detector_factory.c" "intake.c"
     INCLUDE_DIRS "include"
-    REQUIRES ads1115_driver esp_driver_gpio slot_map)
+    REQUIRES ads1115_driver esp_driver_gpio freertos slot_map)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/intake/CMakeLists.txt
+++ b/components/intake/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
-    SRCS "dummy_intake_detector.c" "intake_detector_factory.c"
+    SRCS "dummy_intake_detector.c" "intake_detector_factory.c" "intake.c"
     INCLUDE_DIRS "include"
-    REQUIRES )
+    REQUIRES ads1115_driver esp_driver_gpio)
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)
     target_compile_options(${COMPONENT_LIB} PRIVATE 

--- a/components/intake/include/intake.h
+++ b/components/intake/include/intake.h
@@ -6,5 +6,7 @@
 
 esp_err_t intake_init(void);
 esp_err_t intake_read_slot_raw(uint8_t slot_id, int16_t *out_raw);
+esp_err_t intake_get_slot_threshold(uint8_t slot_id, int16_t *out_threshold);
+esp_err_t intake_set_slot_threshold(uint8_t slot_id, int16_t threshold);
 
 #endif // INTAKE_H

--- a/components/intake/include/intake.h
+++ b/components/intake/include/intake.h
@@ -1,8 +1,10 @@
 #ifndef INTAKE_H
 #define INTAKE_H
 
+#include <stdint.h>
 #include "esp_err.h"
 
 esp_err_t intake_init(void);
+esp_err_t intake_read_slot_raw(uint8_t slot_id, int16_t *out_raw);
 
 #endif // INTAKE_H

--- a/components/intake/include/intake.h
+++ b/components/intake/include/intake.h
@@ -1,0 +1,8 @@
+#ifndef INTAKE_H
+#define INTAKE_H
+
+#include "esp_err.h"
+
+esp_err_t intake_init(void);
+
+#endif // INTAKE_H

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -2,6 +2,8 @@
 #include "ads1115.h"
 #include "slot_map.h"
 #include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "esp_log.h"
 #include <stddef.h>
 
@@ -9,6 +11,81 @@ static const char *TAG = "intake";
 
 #define INTAKE_I2C_SDA_GPIO GPIO_NUM_21
 #define INTAKE_I2C_SCL_GPIO GPIO_NUM_22
+#define INTAKE_DEFAULT_RAW_THRESHOLD 1000
+
+static SemaphoreHandle_t s_threshold_mutex = NULL;
+static int16_t s_thresholds[SLOT_COUNT];
+
+static esp_err_t validate_slot_id(uint8_t slot_id)
+{
+    if (slot_id < 1 || slot_id > SLOT_COUNT) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t init_thresholds(void)
+{
+    if (s_threshold_mutex == NULL) {
+        s_threshold_mutex = xSemaphoreCreateMutex();
+        if (s_threshold_mutex == NULL) {
+            ESP_LOGE(TAG, "threshold mutex create failed");
+            return ESP_ERR_NO_MEM;
+        }
+
+        for (uint8_t i = 0; i < SLOT_COUNT; i++) {
+            s_thresholds[i] = INTAKE_DEFAULT_RAW_THRESHOLD;
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t intake_get_slot_threshold(uint8_t slot_id, int16_t *out_threshold)
+{
+    if (out_threshold == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_err_t err = validate_slot_id(slot_id);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (s_threshold_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (xSemaphoreTake(s_threshold_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_FAIL;
+    }
+
+    *out_threshold = s_thresholds[slot_id - 1];
+    xSemaphoreGive(s_threshold_mutex);
+    return ESP_OK;
+}
+
+esp_err_t intake_set_slot_threshold(uint8_t slot_id, int16_t threshold)
+{
+    esp_err_t err = validate_slot_id(slot_id);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    if (s_threshold_mutex == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (xSemaphoreTake(s_threshold_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_FAIL;
+    }
+
+    s_thresholds[slot_id - 1] = threshold;
+    xSemaphoreGive(s_threshold_mutex);
+    ESP_LOGI(TAG, "intake threshold set: slot=%u threshold=%d", slot_id, threshold);
+    return ESP_OK;
+}
 
 esp_err_t intake_read_slot_raw(uint8_t slot_id, int16_t *out_raw)
 {
@@ -50,7 +127,12 @@ static esp_err_t log_slot_readings(void)
 
 esp_err_t intake_init(void)
 {
-    esp_err_t err = ads1115_bus_init(INTAKE_I2C_SDA_GPIO, INTAKE_I2C_SCL_GPIO);
+    esp_err_t err = init_thresholds();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = ads1115_bus_init(INTAKE_I2C_SDA_GPIO, INTAKE_I2C_SCL_GPIO);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ADS1115 bus init failed: %s", esp_err_to_name(err));
         return err;

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -134,8 +134,13 @@ esp_err_t intake_init(void)
 
     err = ads1115_bus_init(INTAKE_I2C_SDA_GPIO, INTAKE_I2C_SCL_GPIO);
     if (err != ESP_OK) {
+#ifdef CI_BUILD
+        ESP_LOGW(TAG, "ADS1115 bus init failed, continuing without sensor raw reads: %s", esp_err_to_name(err));
+        return ESP_OK;
+#else
         ESP_LOGE(TAG, "ADS1115 bus init failed: %s", esp_err_to_name(err));
         return err;
+#endif
     }
 
     uint8_t addrs[] = {ADS1115_ADDR_LO, ADS1115_ADDR_HI};
@@ -144,15 +149,37 @@ esp_err_t intake_init(void)
 
         err = ads1115_detect(addrs[i], &found);
         if (err != ESP_OK) {
+#ifdef CI_BUILD
+            ESP_LOGW(TAG, "ADS1115 detect failed, continuing without sensor raw reads: addr=0x%02x err=%s",
+                     addrs[i], esp_err_to_name(err));
+            return ESP_OK;
+#else
             ESP_LOGE(TAG, "ADS1115 detect failed: addr=0x%02x err=%s", addrs[i], esp_err_to_name(err));
             return err;
+#endif
         }
 
         if (!found) {
+#ifdef CI_BUILD
+            ESP_LOGW(TAG, "ADS1115 not found, continuing without sensor raw reads: addr=0x%02x", addrs[i]);
+            return ESP_OK;
+#else
             ESP_LOGE(TAG, "ADS1115 not found: addr=0x%02x", addrs[i]);
             return ESP_ERR_NOT_FOUND;
+#endif
         }
     }
 
-    return log_slot_readings();
+    err = log_slot_readings();
+    if (err != ESP_OK) {
+#ifdef CI_BUILD
+        ESP_LOGW(TAG, "ADS1115 initial raw logging failed, continuing without sensor raw reads: %s",
+                 esp_err_to_name(err));
+        return ESP_OK;
+#else
+        return err;
+#endif
+    }
+
+    return ESP_OK;
 }

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -134,7 +134,7 @@ esp_err_t intake_init(void)
 
     err = ads1115_bus_init(INTAKE_I2C_SDA_GPIO, INTAKE_I2C_SCL_GPIO);
     if (err != ESP_OK) {
-#ifdef CI_BUILD
+#ifdef TEST_BUILD
         ESP_LOGW(TAG, "ADS1115 bus init failed, continuing without sensor raw reads: %s", esp_err_to_name(err));
         return ESP_OK;
 #else
@@ -149,7 +149,7 @@ esp_err_t intake_init(void)
 
         err = ads1115_detect(addrs[i], &found);
         if (err != ESP_OK) {
-#ifdef CI_BUILD
+#ifdef TEST_BUILD
             ESP_LOGW(TAG, "ADS1115 detect failed, continuing without sensor raw reads: addr=0x%02x err=%s",
                      addrs[i], esp_err_to_name(err));
             return ESP_OK;
@@ -160,7 +160,7 @@ esp_err_t intake_init(void)
         }
 
         if (!found) {
-#ifdef CI_BUILD
+#ifdef TEST_BUILD
             ESP_LOGW(TAG, "ADS1115 not found, continuing without sensor raw reads: addr=0x%02x", addrs[i]);
             return ESP_OK;
 #else
@@ -172,7 +172,7 @@ esp_err_t intake_init(void)
 
     err = log_slot_readings();
     if (err != ESP_OK) {
-#ifdef CI_BUILD
+#ifdef TEST_BUILD
         ESP_LOGW(TAG, "ADS1115 initial raw logging failed, continuing without sensor raw reads: %s",
                  esp_err_to_name(err));
         return ESP_OK;

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -1,5 +1,6 @@
 #include "intake.h"
 #include "ads1115.h"
+#include "slot_map.h"
 #include "driver/gpio.h"
 #include "esp_log.h"
 #include <stddef.h>
@@ -8,6 +9,31 @@ static const char *TAG = "intake";
 
 #define INTAKE_I2C_SDA_GPIO GPIO_NUM_21
 #define INTAKE_I2C_SCL_GPIO GPIO_NUM_22
+
+static esp_err_t log_slot_readings(void)
+{
+    for (uint8_t slot_id = 1; slot_id <= SLOT_COUNT; slot_id++) {
+        const SlotHwConfig *cfg = NULL;
+        esp_err_t err = slot_map_get(slot_id, &cfg);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "slot map lookup failed: slot=%u err=%s", slot_id, esp_err_to_name(err));
+            return err;
+        }
+
+        int16_t raw = 0;
+        err = ads1115_read_channel(cfg->ads1115_addr, cfg->ads1115_channel, &raw);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "ADS1115 read failed: slot=%u addr=0x%02x ch=%u err=%s",
+                     slot_id, cfg->ads1115_addr, cfg->ads1115_channel, esp_err_to_name(err));
+            return err;
+        }
+
+        ESP_LOGI(TAG, "intake sensor raw: slot=%u addr=0x%02x ch=%u value=%d",
+                 slot_id, cfg->ads1115_addr, cfg->ads1115_channel, raw);
+    }
+
+    return ESP_OK;
+}
 
 esp_err_t intake_init(void)
 {
@@ -33,5 +59,5 @@ esp_err_t intake_init(void)
         }
     }
 
-    return ESP_OK;
+    return log_slot_readings();
 }

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -1,0 +1,37 @@
+#include "intake.h"
+#include "ads1115.h"
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include <stddef.h>
+
+static const char *TAG = "intake";
+
+#define INTAKE_I2C_SDA_GPIO GPIO_NUM_21
+#define INTAKE_I2C_SCL_GPIO GPIO_NUM_22
+
+esp_err_t intake_init(void)
+{
+    esp_err_t err = ads1115_bus_init(INTAKE_I2C_SDA_GPIO, INTAKE_I2C_SCL_GPIO);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "ADS1115 bus init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    uint8_t addrs[] = {ADS1115_ADDR_LO, ADS1115_ADDR_HI};
+    for (size_t i = 0; i < sizeof(addrs) / sizeof(addrs[0]); i++) {
+        bool found = false;
+
+        err = ads1115_detect(addrs[i], &found);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "ADS1115 detect failed: addr=0x%02x err=%s", addrs[i], esp_err_to_name(err));
+            return err;
+        }
+
+        if (!found) {
+            ESP_LOGE(TAG, "ADS1115 not found: addr=0x%02x", addrs[i]);
+            return ESP_ERR_NOT_FOUND;
+        }
+    }
+
+    return ESP_OK;
+}

--- a/components/intake/intake.c
+++ b/components/intake/intake.c
@@ -10,26 +10,39 @@ static const char *TAG = "intake";
 #define INTAKE_I2C_SDA_GPIO GPIO_NUM_21
 #define INTAKE_I2C_SCL_GPIO GPIO_NUM_22
 
+esp_err_t intake_read_slot_raw(uint8_t slot_id, int16_t *out_raw)
+{
+    if (out_raw == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const SlotHwConfig *cfg = NULL;
+    esp_err_t err = slot_map_get(slot_id, &cfg);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "slot map lookup failed: slot=%u err=%s", slot_id, esp_err_to_name(err));
+        return err;
+    }
+
+    err = ads1115_read_channel(cfg->ads1115_addr, cfg->ads1115_channel, out_raw);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "ADS1115 read failed: slot=%u addr=0x%02x ch=%u err=%s",
+                 slot_id, cfg->ads1115_addr, cfg->ads1115_channel, esp_err_to_name(err));
+        return err;
+    }
+
+    return ESP_OK;
+}
+
 static esp_err_t log_slot_readings(void)
 {
     for (uint8_t slot_id = 1; slot_id <= SLOT_COUNT; slot_id++) {
-        const SlotHwConfig *cfg = NULL;
-        esp_err_t err = slot_map_get(slot_id, &cfg);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "slot map lookup failed: slot=%u err=%s", slot_id, esp_err_to_name(err));
-            return err;
-        }
-
         int16_t raw = 0;
-        err = ads1115_read_channel(cfg->ads1115_addr, cfg->ads1115_channel, &raw);
+        esp_err_t err = intake_read_slot_raw(slot_id, &raw);
         if (err != ESP_OK) {
-            ESP_LOGE(TAG, "ADS1115 read failed: slot=%u addr=0x%02x ch=%u err=%s",
-                     slot_id, cfg->ads1115_addr, cfg->ads1115_channel, esp_err_to_name(err));
             return err;
         }
 
-        ESP_LOGI(TAG, "intake sensor raw: slot=%u addr=0x%02x ch=%u value=%d",
-                 slot_id, cfg->ads1115_addr, cfg->ads1115_channel, raw);
+        ESP_LOGI(TAG, "intake sensor raw: slot=%u value=%d", slot_id, raw);
     }
 
     return ESP_OK;

--- a/components/motor/CMakeLists.txt
+++ b/components/motor/CMakeLists.txt
@@ -11,3 +11,6 @@ if(CI_BUILD)
         -Wno-unused-parameter
     )
 endif()
+if(TEST_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TEST_BUILD)
+endif()

--- a/components/motor/servo_driver_factory.c
+++ b/components/motor/servo_driver_factory.c
@@ -1,9 +1,9 @@
 #include "servo_driver_factory.h"
 
-#ifdef CI_BUILD
+#if defined(CI_BUILD) || defined(TEST_BUILD)
 #include "dummy_servo_driver.h"
 
-// Get the default servo driver instance, which is a dummy driver in CI build
+// Get the default servo driver instance, which is a dummy driver in CI/test builds.
 const ServoDriver *get_default_servo_driver(void) {
     return &DUMMY_SERVO_DRIVER;
 }

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -11,3 +11,6 @@ if(CI_BUILD)
         -Wno-unused-parameter
     )
 endif()
+if(TEST_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TEST_BUILD)
+endif()

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(
     SRCS "main.c"
     INCLUDE_DIRS "."
-    REQUIRES storage wifi rtc schedule dispense motor event_queue)
+    REQUIRES storage wifi rtc schedule dispense motor event_queue intake)
 
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)

--- a/main/main.c
+++ b/main/main.c
@@ -7,6 +7,7 @@
 #include "dispense.h"
 #include "motor_task.h"
 #include "event_queue.h"
+#include "intake.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -33,6 +34,13 @@ void app_main(void)
 
     // Initialize RTC and check for errors
     ESP_ERROR_CHECK(rtc_driver_init());
+
+    // Initialize intake module and check for errors
+    err = intake_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize intake");
+        return;
+    }
 
     // Create the heartbeat task
     BaseType_t heartbeat_task_created = xTaskCreate(

--- a/main/main.c
+++ b/main/main.c
@@ -71,8 +71,8 @@ void app_main(void)
         return;
     }
 
-#ifdef CI_BUILD
-    // Temporary fixture schedule for CI/store integration testing only.
+#if defined(CI_BUILD) || defined(TEST_BUILD)
+    // Temporary fixture schedule for CI/store integration and local test builds.
     err = schedule_store_apply_fixture();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to apply fixture schedule");


### PR DESCRIPTION
## 📌 Related Issue

Closes #41

## 🚀 Description

- Add an ADS1115 driver component for two ADC devices at 0x48 and 0x49.
- Initialize ADS1115 through the intake module and log per-slot raw readings.
- Preserve ADS1115 probe bus errors while treating only missing devices as not found.
- Expose slot raw-read and threshold configuration APIs without changing TAKEN/MISSED behavior.
- Split local sensor fallback into `TEST_BUILD`, while keeping `CI_BUILD` for CI/example config.

## 📢 Review Point

- Confirm ADS1115 probe returns timeout/bus errors instead of collapsing them into missing-device status.
- Confirm non-test builds fail intake initialization when ADS1115 bus, probe, or raw logging fails.
- Confirm `TEST_BUILD` keeps fixture schedule, dummy servo, and ADS1115 fallback without using CI example Wi-Fi config.
- Check slot_map-based slot-to-ADS1115 address/channel mapping for all 8 slots.
- Confirm threshold APIs only store configuration and do not introduce TAKEN detection logic.

## 📚 Etc

### Verification Criteria
- Normal build logs show ADS1115 detection and one raw ADC reading for each slot 1 through 8.
- Normal build logs show intake initialization fails when ADS1115 bus/probe/raw logging fails.
- `TEST_BUILD` logs warn and continue without sensor raw reads, then dummy intake timeout still reports MISSED.
- `CI_BUILD` continues to compile with example Wi-Fi/HTTP config for GitHub validation.

### Verification Evidence
1. 일반 빌드: ADS1115 failure $\to$ startup failure
<img width="1521" height="773" alt="Screenshot 2026-06-02 174024" src="https://github.com/user-attachments/assets/d9aac3c9-8273-4ec4-ba50-f816c873d35e" />
2. Test Build: dummy_intake로 대체
<img width="1525" height="898" alt="Screenshot 2026-06-02 174856" src="https://github.com/user-attachments/assets/d1bf057f-d932-439e-aac7-c47996e7fba5" />
