### PR TITLE
Feat: Support six slots across hardware and schedule paths

### DIFF
--- a/components/schedule/include/schedule.h
+++ b/components/schedule/include/schedule.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define SCHEDULE_SLOT_COUNT 8
+#define SCHEDULE_SLOT_COUNT 6
 #define SCHEDULE_TASK_STACK_SIZE 4096
 #define SCHEDULE_TASK_PRIORITY 5
 

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -22,8 +22,6 @@ static const SlotEntry s_fixture_slots[] = {
     { .slot_id = 4, .hour = 22, .minute = 15, .triggered = false },
     { .slot_id = 5, .hour = 22, .minute = 16, .triggered = false },
     { .slot_id = 6, .hour = 22, .minute = 17, .triggered = false },
-    { .slot_id = 7, .hour = 22, .minute = 18, .triggered = false },
-    { .slot_id = 8, .hour = 22, .minute = 19, .triggered = false },
 };
 
 static void log_applied_slots(const SlotEntry *slots, size_t count, uint32_t version)

--- a/components/slot_map/include/slot_map.h
+++ b/components/slot_map/include/slot_map.h
@@ -5,7 +5,7 @@
 #include "driver/gpio.h"
 #include "esp_err.h"
 
-#define SLOT_COUNT 8
+#define SLOT_COUNT 6
 
 typedef struct {
     gpio_num_t servo_gpio;

--- a/components/slot_map/slot_map.c
+++ b/components/slot_map/slot_map.c
@@ -3,12 +3,10 @@
 static const SlotHwConfig s_slot_map[SLOT_COUNT] = {
     {GPIO_NUM_13, 0x48, 0}, // slot_id=1
     {GPIO_NUM_14, 0x48, 1}, // slot_id=2
-    {GPIO_NUM_15, 0x48, 2}, // slot_id=3
-    {GPIO_NUM_16, 0x48, 3}, // slot_id=4
-    {GPIO_NUM_17, 0x49, 0}, // slot_id=5
-    {GPIO_NUM_18, 0x49, 1}, // slot_id=6
-    {GPIO_NUM_19, 0x49, 2}, // slot_id=7
-    {GPIO_NUM_23, 0x49, 3}, // slot_id=8
+    {GPIO_NUM_16, 0x48, 2}, // slot_id=3
+    {GPIO_NUM_17, 0x48, 3}, // slot_id=4
+    {GPIO_NUM_18, 0x49, 0}, // slot_id=5
+    {GPIO_NUM_19, 0x49, 1}, // slot_id=6
 };
 
 esp_err_t slot_map_get(uint8_t slot_id, const SlotHwConfig **out)


### PR DESCRIPTION
## 📌 Related Issue

Closes #50

## 🚀 Description

- Update the shared slot hardware map from eight slots to six slots.
- Apply the issue-provided servo GPIO and ADS1115 address/channel mapping for slots 1-6.
- Limit schedule storage, validation, fixture data, and duplicate-trigger tracking to six slots.

## 📢 Review Point

- Check that servo and ADS1115 paths use the same six-slot `slot_map` configuration.
- Check that schedule validation rejects slot IDs outside 1-6.
- Check that duplicate schedule trigger prevention still records each six-slot event once per day.

## 📚 Etc

### Verification Criteria
- CI build completes with `idf.py -DCI_BUILD=1 build`.
- Device logs show six-slot servo initialization and ADS1115 slot reads with the updated mapping.
- Device logs show schedule events for slots 1-6 without duplicate enqueue behavior.

### Verification Evidence
`TEST_BUILD` 기준 자알 돌아감

<img width="1520" height="1000" alt="Screenshot 2026-06-02 180749" src="https://github.com/user-attachments/assets/066fd862-be89-4b58-a8de-e2797c7d3ad4" />
<img width="1521" height="1335" alt="Screenshot 2026-06-02 180807" src="https://github.com/user-attachments/assets/52e76d00-2506-4891-98d3-94f371f428af" />
