### PR TITLE
Test: Validate six-slot servo hardware run

### DIFF
--- a/components/motor/servo_driver_factory.c
+++ b/components/motor/servo_driver_factory.c
@@ -1,6 +1,6 @@
 #include "servo_driver_factory.h"
 
-#if defined(CI_BUILD) || defined(TEST_BUILD)
+#if defined(CI_BUILD)
 #include "dummy_servo_driver.h"
 
 // Get the default servo driver instance, which is a dummy driver in CI/test builds.

--- a/components/schedule/schedule_store.c
+++ b/components/schedule/schedule_store.c
@@ -16,12 +16,12 @@ static bool s_refresh_pending = false;
 static uint32_t s_refresh_request_count = 0;
 
 static const SlotEntry s_fixture_slots[] = {
-    { .slot_id = 1, .hour = 22, .minute = 12, .triggered = false },
-    { .slot_id = 2, .hour = 22, .minute = 13, .triggered = false },
-    { .slot_id = 3, .hour = 22, .minute = 14, .triggered = false },
-    { .slot_id = 4, .hour = 22, .minute = 15, .triggered = false },
-    { .slot_id = 5, .hour = 22, .minute = 16, .triggered = false },
-    { .slot_id = 6, .hour = 22, .minute = 17, .triggered = false },
+    { .slot_id = 1, .hour = 22, .minute = 32, .triggered = false },
+    { .slot_id = 2, .hour = 22, .minute = 33, .triggered = false },
+    { .slot_id = 3, .hour = 22, .minute = 34, .triggered = false },
+    { .slot_id = 4, .hour = 22, .minute = 35, .triggered = false },
+    { .slot_id = 5, .hour = 22, .minute = 36, .triggered = false },
+    { .slot_id = 6, .hour = 22, .minute = 37, .triggered = false },
 };
 
 static void log_applied_slots(const SlotEntry *slots, size_t count, uint32_t version)


### PR DESCRIPTION
## 📌 Related Issue

Closes #53

## 🚀 Description

- Keep `CI_BUILD` on the dummy servo driver while letting `TEST_BUILD` use the LEDC servo driver.
- Update the six-slot fixture schedule to consecutive hardware test times.
- Preserve the six-slot validation path used for the real servo run.

## 📢 Review Point

- Check that only `CI_BUILD` is routed to the dummy servo driver.
- Check that the fixture still contains exactly six valid slot entries.
- Check that the schedule times support one event per slot during local hardware validation.

## 📚 Etc

### Verification Criteria
- `idf.py -DCI_BUILD=1 build` completes successfully.
- TEST_BUILD hardware logs show slot match and servo open/close for all six slots.
- Each fixture slot is triggered once at its configured minute.

### Verification Evidence
- CI build: passed locally.
- Hardware log screenshot: to be attached by the user.