### PR TITLE
Fix: skip MQTT setup for CI and test builds

### DIFF
--- a/components/mqtt_client/CMakeLists.txt
+++ b/components/mqtt_client/CMakeLists.txt
@@ -13,3 +13,7 @@ if(CI_BUILD)
         -Wno-unused-parameter
     )
 endif()
+
+if(TEST_BUILD)
+    target_compile_definitions(${COMPONENT_LIB} PRIVATE TEST_BUILD)
+endif()

--- a/components/mqtt_client/ongi_mqtt_client.c
+++ b/components/mqtt_client/ongi_mqtt_client.c
@@ -1,5 +1,32 @@
 #include "ongi_mqtt_client.h"
 
+#if defined(CI_BUILD) || defined(TEST_BUILD)
+
+#include "esp_err.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+static const char *TAG = "ongi-mqtt-client";
+
+esp_err_t ongi_mqtt_client_init(void) {
+    ESP_LOGI(TAG, "MQTT client setup skipped for CI/TEST build");
+    return ESP_OK;
+}
+
+esp_err_t ongi_mqtt_client_start(void) {
+    ESP_LOGI(TAG, "MQTT client start skipped for CI/TEST build");
+    return ESP_OK;
+}
+
+void ongi_mqtt_client_task(void *arg) {
+    (void)arg;
+    ESP_LOGI(TAG, "MQTT client task skipped for CI/TEST build");
+    vTaskDelete(NULL);
+}
+
+#else
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -11,13 +38,8 @@
 #include "mqtt_client.h"
 #include "wifi_heartbeat.h"
 
-#ifdef CI_BUILD
-    #include "wifi_config_example.h"
-    #include "mqtt_config_example.h"
-#else
-    #include "wifi_config.h"
-    #include "mqtt_config.h"
-#endif
+#include "wifi_config.h"
+#include "mqtt_config.h"
 
 static const char *TAG = "ongi-mqtt-client";
 
@@ -287,3 +309,5 @@ void ongi_mqtt_client_task(void *arg) {
         vTaskDelay(pdMS_TO_TICKS(MQTT_START_RETRY_DELAY_MS));
     }
 }
+
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -7,12 +7,15 @@
 #include "dispense.h"
 #include "motor_task.h"
 #include "event_queue.h"
-#include "ongi_mqtt_client.h"
 #include "intake.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
 #include "esp_err.h"
+
+#if !defined(CI_BUILD) && !defined(TEST_BUILD)
+#include "ongi_mqtt_client.h"
+#endif
 
 void app_main(void)
 {
@@ -43,12 +46,14 @@ void app_main(void)
         return;
     }
 
+#if !defined(CI_BUILD) && !defined(TEST_BUILD)
     // Initialize MQTT client and prepare command topics
     err = ongi_mqtt_client_init();
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to initialize MQTT client: %s", esp_err_to_name(err));
         return;
     }
+#endif
 
     // Create the heartbeat task
     BaseType_t heartbeat_task_created = xTaskCreate(
@@ -65,6 +70,7 @@ void app_main(void)
         return;
     }
 
+#if !defined(CI_BUILD) && !defined(TEST_BUILD)
     // Create the MQTT client task
     BaseType_t mqtt_task_created = xTaskCreate(
         ongi_mqtt_client_task,
@@ -78,6 +84,7 @@ void app_main(void)
         ESP_LOGE(TAG, "Failed to create MQTT client task");
         return;
     }
+#endif
 
     // Initialize dispense module and check for errors
     err = dispense_init();


### PR DESCRIPTION
## 📌 Related Issue

Closes #55

## 🚀 Description
하드웨어 동작과 서버 connection을 분리하여 테스트하기 위해 `TEST_BUILD`에서는 MQTT 설정을 하지 않도록 수정함.
- Skip MQTT header usage, initialization, and task creation from `app_main` for `CI_BUILD` and `TEST_BUILD`.
- Keep MQTT client APIs as no-op stubs for CI/test builds so broker settings are not required.
- Propagate `TEST_BUILD` to the MQTT component.

## 📢 Review Point

- Check that production builds still initialize MQTT with real config values.
- Check that CI/test builds do not create the MQTT retry task or reference broker credentials.

## 📚 Etc

### Verification Criteria
- CI/test startup logs should not show MQTT topic preparation, broker connection, or MQTT retry task logs.
- Production startup logs should still show MQTT topic preparation and client start after Wi-Fi connection.

### Verification Evidence
- `TEST_BUILD=1` 옵션으로 빌드 시 MQTT 연결 설정을 건너뜀
<img width="1501" height="663" alt="Screenshot 2026-06-03 014614" src="https://github.com/user-attachments/assets/f262bff8-8219-44b7-b0e8-04d5c220fe2b" />
<img width="1501" height="1366" alt="Screenshot 2026-06-03 014601" src="https://github.com/user-attachments/assets/d465f57c-9a2e-4a2c-b951-1ddfa8a659e9" />
