### PR TITLE
Feat: Handle MQTT schedule refresh signal safely

### DIFF
--- a/components/mqtt_client/CMakeLists.txt
+++ b/components/mqtt_client/CMakeLists.txt
@@ -2,7 +2,7 @@ idf_component_register(
     SRCS "ongi_mqtt_client.c"
     INCLUDE_DIRS "include"
     PRIV_INCLUDE_DIRS "../wifi"
-    PRIV_REQUIRES mqtt wifi motor
+    PRIV_REQUIRES mqtt wifi motor schedule
 )
 
 if(CI_BUILD)

--- a/components/mqtt_client/CMakeLists.txt
+++ b/components/mqtt_client/CMakeLists.txt
@@ -1,9 +1,17 @@
-idf_component_register(
-    SRCS "ongi_mqtt_client.c"
-    INCLUDE_DIRS "include"
-    PRIV_INCLUDE_DIRS "../wifi"
-    PRIV_REQUIRES mqtt wifi motor schedule
-)
+if(CI_BUILD OR TEST_BUILD)
+    idf_component_register(
+        SRCS "ongi_mqtt_client.c"
+        INCLUDE_DIRS "include"
+        PRIV_REQUIRES esp_common freertos log
+    )
+else()
+    idf_component_register(
+        SRCS "ongi_mqtt_client.c"
+        INCLUDE_DIRS "include"
+        PRIV_INCLUDE_DIRS "../wifi"
+        PRIV_REQUIRES mqtt wifi motor schedule
+    )
+endif()
 
 if(CI_BUILD)
     target_compile_definitions(${COMPONENT_LIB} PRIVATE CI_BUILD)

--- a/components/mqtt_client/ongi_mqtt_client.c
+++ b/components/mqtt_client/ongi_mqtt_client.c
@@ -37,6 +37,7 @@ void ongi_mqtt_client_task(void *arg) {
 #include "freertos/task.h"
 #include "mqtt_client.h"
 #include "motor_task.h"
+#include "schedule_store.h"
 #include "wifi_heartbeat.h"
 
 #include "wifi_config.h"
@@ -49,6 +50,7 @@ static const char *TAG = "ongi-mqtt-client";
 #define MQTT_COMMAND_QOS 1
 #define MQTT_OPEN_ALL_PAYLOAD "OPEN_ALL"
 #define MQTT_CLOSE_ALL_PAYLOAD "CLOSE_ALL"
+#define MQTT_SCHEDULE_UPDATED_PAYLOAD "SCHEDULE_UPDATED"
 #define MQTT_DUPLICATE_SUPPRESS_WINDOW_MS 30000
 
 typedef struct {
@@ -195,6 +197,36 @@ static void log_received_command_metadata(const esp_mqtt_event_handle_t event) {
 
 static void handle_mqtt_command_data(const esp_mqtt_event_handle_t event) {
     log_received_command_metadata(event);
+
+    if (event != NULL &&
+        mqtt_topic_matches(event->topic, event->topic_len, s_command_topics.schedule_updated)) {
+        if (event->data == NULL ||
+            event->current_data_offset != 0 ||
+            event->data_len != event->total_data_len) {
+            ESP_LOGW(TAG,
+                     "MQTT schedule refresh payload fragment ignored: payload_len=%d total_payload_len=%d offset=%d",
+                     event->data_len,
+                     event->total_data_len,
+                     event->current_data_offset);
+            return;
+        }
+
+        if (!mqtt_bytes_match(event->data, event->data_len, MQTT_SCHEDULE_UPDATED_PAYLOAD)) {
+            ESP_LOGW(TAG, "MQTT schedule refresh payload rejected: payload_len=%d", event->data_len);
+            return;
+        }
+
+        esp_err_t refresh_err = schedule_store_request_refresh();
+        if (refresh_err != ESP_OK) {
+            ESP_LOGW(TAG,
+                     "MQTT schedule refresh ignored until schedule store is ready: err=%s",
+                     esp_err_to_name(refresh_err));
+            return;
+        }
+
+        ESP_LOGI(TAG, "MQTT schedule refresh notification accepted");
+        return;
+    }
 
     MotorCommand command;
     esp_err_t err = get_motor_command_from_event(event, &command);

--- a/components/schedule/schedule.c
+++ b/components/schedule/schedule.c
@@ -53,6 +53,25 @@ static void mark_triggered_today(TriggerRecord *records, size_t count, const Slo
              (unsigned int)slot->minute);
 }
 
+static void consume_schedule_refresh_request(void) {
+    bool refresh_pending = false;
+    uint32_t request_count = 0;
+
+    esp_err_t err = schedule_store_consume_refresh_request(&refresh_pending, &request_count);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to consume schedule refresh request: %s", esp_err_to_name(err));
+        return;
+    }
+
+    if (!refresh_pending) {
+        return;
+    }
+
+    ESP_LOGI(TAG,
+             "Schedule refresh notification consumed: request_count=%u fetch_status=pending_contract",
+             (unsigned int)request_count);
+}
+
 void schedule_task(void *arg) {
     ESP_LOGI(TAG, "Schedule task started");
 
@@ -70,6 +89,8 @@ void schedule_task(void *arg) {
 
     // Main loop to check and trigger scheduled slots
     while (1) {
+        consume_schedule_refresh_request();
+
         time_t now;
         // Get current time from RTC
         esp_err_t err = rtc_driver_get_time(&now);

--- a/docs/schedule-fetch-contract.md
+++ b/docs/schedule-fetch-contract.md
@@ -1,0 +1,45 @@
+# Schedule Fetch Contract
+
+## Server Contract
+
+- Endpoint: `GET /api/device/schedules`
+- Auth: `Device-Token` header
+- Response data: array of schedule entries sorted by slot number
+- Entry fields:
+  - `slotNumber`: 1-based device slot number
+  - `scheduledTime`: local time string from the server, for example `08:00:00`
+
+Example response:
+
+```json
+{
+  "isSuccess": true,
+  "code": "DEVICE_200",
+  "message": "디바이스 스케줄 조회에 성공했습니다.",
+  "data": [
+    {
+      "slotNumber": 1,
+      "scheduledTime": "08:00:00"
+    }
+  ]
+}
+```
+
+## Device Behavior For Issue #35
+
+- MQTT `SCHEDULE_UPDATED` is only a refresh notification.
+- Receiving `SCHEDULE_UPDATED` must not enqueue a dispense event.
+- Until the device-side HTTP fetch and parsing flow is implemented, the schedule task only logs that a refresh notification was consumed.
+- Unknown payloads on the schedule-updated topic are ignored.
+
+## Pending Device Work
+
+- Fetch schedules from `GET /api/device/schedules` after a validated refresh notification.
+- Validate `slotNumber` against `SCHEDULE_SLOT_COUNT`.
+- Parse `scheduledTime` into hour/minute before calling `schedule_store_apply()`.
+- Handle HTTP timeout, non-2xx status, malformed JSON, duplicate slots, and empty schedule responses without changing hardware state.
+
+#### Sources
+
+- Server PR: `Ongi-Team/ongi-server#63`
+- Device issue: `Ongi-Team/ongi-device#35`


### PR DESCRIPTION
## 📌 Related Issue

Closes #35

## 🚀 Description

- Accept MQTT `SCHEDULE_UPDATED` only as a schedule refresh notification.
- Route valid refresh payloads into the schedule store without enqueueing dispense events.
- Log consumed refresh requests and document the pending server schedule fetch contract.
- Keep MQTT client behavior stubbed for CI/TEST builds.

## 📢 Review Point

- Check that `SCHEDULE_UPDATED` cannot reach `dispense_enqueue()` directly.
- Check schedule-store refresh pending state across MQTT and schedule tasks.
- Check TEST_BUILD/CI_BUILD MQTT client stubbing and dependency split.

## 📚 Etc

### Verification Criteria
- Publishing `SCHEDULE_UPDATED` logs an accepted refresh notification.
- Schedule task logs the consumed refresh request after RTC sync.
- Invalid schedule-updated payloads are logged and ignored.
- No dispense event is enqueued from `SCHEDULE_UPDATED` alone.

### Verification Evidence
- PASS: `idf.py -B build-ci -DCI_BUILD=1 build`
- PASS: `idf.py -B build-test -DTEST_BUILD=1 build`
- PASS: `git diff --check main..HEAD`
- Log screenshot: to be attached